### PR TITLE
Update design principles and other docs

### DIFF
--- a/docs/approaches.md
+++ b/docs/approaches.md
@@ -4,18 +4,13 @@
 
 ## Design Principles
 
-Whatever approach is adopted, community members have highlighted several principles:
-
-> "There should be intentional focus on making it easy for server authors to create and expose skills... client hosts are strongly incentivized to have a relatively uniform way to discover and consume them — at least from the point of view of a server author — while also leaving room for client host innovation.
->
-> I also don't like creating dichotomy between first-class skills and skills as context, because pretty much everything an MCP server exposes is context. Skills-as-resources is much more accurate." — [Peder Holdgaard Pedersen](https://github.com/PederHP)
-
-Building on this, several design considerations are emerging from community discussion:
+Several design considerations are emerging from community discussion:
 
 - **MCP is fundamentally about context, not just tools.** Skills are part of a broader challenge around context-as-resources discoverability and standardization of client host behavior. Framing skills as context-as-resources avoids creating artificial hierarchies between skills and other MCP primitives.
 - **Don't be too prescriptive about client host behavior.** Client hosts may want to innovate on how skills are utilized (e.g., progressive disclosure) and what they can even *be*. The goal is uniform discovery and consumption patterns from the server author's perspective, while leaving room for client-side innovation.
 - **Don't assume how tool paradigms will evolve.** The conceptual surface of skills shouldn't bake in assumptions about how tools develop. That doesn't preclude skills being implemented as a well-known tool, but the design should not couple skills to any particular tool evolution path.
 - **Let the primitive choice follow from the use case.** The answer may not be "resources" or "new primitive" — it may be both, depending on the interaction pattern. Some skills are context for the model. Some are context for the human. Some are both. The delivery mechanism should support that range. ([See related thread on SEP 2076](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2076#discussion_r2736299627))
+- **Minimize ecosystem complexity.** The broader AI tooling ecosystem is experiencing complexity fatigue — too many overlapping concepts (servers, skills, plugins, hooks, agents) erode credibility and adoption. Whatever approach the IG recommends should reuse existing MCP primitives where possible and only introduce new surface area when there's a clear case that existing primitives can't serve the need. ([See related issue](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/14))
 
 ## Central Tension: Convention vs. Protocol Extension
 
@@ -75,9 +70,13 @@ Examples:
 
 > "I wonder if a better way to approach this with existing primitives is by implementing a Skill() tool and establishing this as a standard recommendation for servers and clients, rather than adding a new primitive to MCP." — [Ola Hungerford](https://github.com/olaservo)
 
+> "There should be intentional focus on making it easy for server authors to create and expose skills... client hosts are strongly incentivized to have a relatively uniform way to discover and consume them — at least from the point of view of a server author — while also leaving room for client host innovation.
+>
+> I also don't like creating dichotomy between first-class skills and skills as context, because pretty much everything an MCP server exposes is context. Skills-as-resources is much more accurate." — [Peder Holdgaard Pedersen](https://github.com/PederHP)
+
 This approach may also:
 
-- Expose skills as MCP resources
+- Use resource templates for parameterized skill discovery
 - Use Prompts for explicit skill invocation
 - Use `tools/listChanged` and other notifications for dynamic updates without server re-initialization
 

--- a/docs/approaches.md
+++ b/docs/approaches.md
@@ -10,7 +10,7 @@ Whatever approach is adopted, community members have highlighted several princip
 >
 > I also don't like creating dichotomy between first-class skills and skills as context, because pretty much everything an MCP server exposes is context. Skills-as-resources is much more accurate." — [Peder Holdgaard Pedersen](https://github.com/PederHP)
 
-Additional design considerations raised by community members:
+Building on this, several design considerations are emerging from community discussion:
 
 - **MCP is fundamentally about context, not just tools.** Skills are part of a broader challenge around context-as-resources discoverability and standardization of client host behavior. Framing skills as context-as-resources avoids creating artificial hierarchies between skills and other MCP primitives.
 - **Don't be too prescriptive about client host behavior.** Client hosts may want to innovate on how skills are utilized (e.g., progressive disclosure) and what they can even *be*. The goal is uniform discovery and consumption patterns from the server author's perspective, while leaving room for client-side innovation.

--- a/docs/approaches.md
+++ b/docs/approaches.md
@@ -6,7 +6,15 @@
 
 Whatever approach is adopted, community members have highlighted several principles:
 
-> "There should be intentional focus on making it easy for server authors to create and expose skills... client hosts are strongly incentivized to have a relatively uniform way to discover and consume them — at least from the point of view of a server author — while also leaving room for client host innovation." — [Peder Holdgaard Pedersen](https://github.com/PederHP)
+> "There should be intentional focus on making it easy for server authors to create and expose skills... client hosts are strongly incentivized to have a relatively uniform way to discover and consume them — at least from the point of view of a server author — while also leaving room for client host innovation.
+>
+> I also don't like creating dichotomy between first-class skills and skills as context, because pretty much everything an MCP server exposes is context. Skills-as-resources is much more accurate." — [Peder Holdgaard Pedersen](https://github.com/PederHP)
+
+Additional design considerations raised by community members:
+
+- **MCP is fundamentally about context, not just tools.** Skills are part of a broader challenge around context-as-resources discoverability and standardization of client host behavior. Framing skills as context-as-resources avoids creating artificial hierarchies between skills and other MCP primitives.
+- **Don't be too prescriptive about client host behavior.** Client hosts may want to innovate on how skills are utilized (e.g., progressive disclosure) and what they can even *be*. The goal is uniform discovery and consumption patterns from the server author's perspective, while leaving room for client-side innovation.
+- **Don't assume how tool paradigms will evolve.** The conceptual surface of skills shouldn't bake in assumptions about how tools develop. That doesn't preclude skills being implemented as a well-known tool, but the design should not couple skills to any particular tool evolution path.
 
 ## Central Tension: Convention vs. Protocol Extension
 

--- a/docs/approaches.md
+++ b/docs/approaches.md
@@ -74,6 +74,8 @@ Examples:
 >
 > I also don't like creating dichotomy between first-class skills and skills as context, because pretty much everything an MCP server exposes is context. Skills-as-resources is much more accurate." — [Peder Holdgaard Pedersen](https://github.com/PederHP)
 
+> "The only slight concern I have is the idea that there are still 'first class skills' (skills that agents recognize as skills, can be presented as skills through the user agent, can be bundled with subagents, etc) and these sort of 'skills as context' approaches where the agent can certainly discover and ingest the skills data, but possibly with some differences compared to how they would apply first class skills." — [Bob Dickinson](https://github.com/TeamSparkAI)
+
 This approach may also:
 
 - Use resource templates for parameterized skill discovery

--- a/docs/approaches.md
+++ b/docs/approaches.md
@@ -15,12 +15,13 @@ Building on this, several design considerations are emerging from community disc
 - **MCP is fundamentally about context, not just tools.** Skills are part of a broader challenge around context-as-resources discoverability and standardization of client host behavior. Framing skills as context-as-resources avoids creating artificial hierarchies between skills and other MCP primitives.
 - **Don't be too prescriptive about client host behavior.** Client hosts may want to innovate on how skills are utilized (e.g., progressive disclosure) and what they can even *be*. The goal is uniform discovery and consumption patterns from the server author's perspective, while leaving room for client-side innovation.
 - **Don't assume how tool paradigms will evolve.** The conceptual surface of skills shouldn't bake in assumptions about how tools develop. That doesn't preclude skills being implemented as a well-known tool, but the design should not couple skills to any particular tool evolution path.
+- **Let the primitive choice follow from the use case.** The answer may not be "resources" or "new primitive" — it may be both, depending on the interaction pattern. Some skills are context for the model. Some are context for the human. Some are both. The delivery mechanism should support that range. ([See related thread on SEP 2076](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2076#discussion_r2736299627))
 
 ## Central Tension: Convention vs. Protocol Extension
 
 The approaches below span a spectrum. At one end, skills become a first-class MCP primitive with dedicated protocol methods (Approach 1). At the other, existing primitives are used with documented conventions (Approach 6). A key question for this IG is whether convention can prove patterns before standardization — or whether the ecosystem needs protocol-level support to achieve reliable interoperability. These are not mutually exclusive; convention work can inform and de-risk a future protocol extension.
 
-## 1. Skills as MCP Primitives
+## 1. Skills as Distinct MCP Primitives
 
 Add Agent Skills as a first-class, discoverable primitive in MCP. A skill is a named bundle of instructions plus references to tools, prompts, and resources that together teach an agent how to perform a domain-specific workflow.
 
@@ -56,14 +57,19 @@ Add skill references to MCP registry entries so users know to install associated
 
 > "We view skills as an opportunity to use them as both a standalone (general-purpose capabilities) & MCP-paired (tool-specific guidance). For the main registry, the binding could be softer: optional fields like suggestedSkills or recommendedSkills rather than definitive pairing, since skill authorship is often decoupled from server authorship." — [Mat Goldsborough](https://github.com/mgoldsborough)
 
-## 3. Skills as Tools
+## 3. Skills as Tools and/or Resources
 
-Expose skills via tools like `list_skills` and `read_skills`. Server instructions can direct the agent to call the skill tool first.
+Examples:
+
+- Expose skills via tools like `list_skills` and `read_skills`. Server instructions can direct the agent to call the skill tool first.
+- Expose skills as resources (e.g. skill://...), which can also be exposed through tools
+
 
 **Implementations:** 
 
 - [skilljack-mcp](https://github.com/olaservo/skilljack-mcp)
 - [skills-over-mcp](https://github.com/keithagroves/skills-over-mcp)
+- [my-cool-proxy](https://github.com/karashiiro/my-cool-proxy)
 
 **Community input:**
 

--- a/docs/open-questions.md
+++ b/docs/open-questions.md
@@ -6,21 +6,13 @@ Should skills be discoverable through registry metadata ("if you install this se
 
 ## 2. How do "first-class" skills differ from "skills as context"?
 
-Native agent skills can be presented through the user agent, bundled with subagents, etc. Do MCP-surfaced skills lose capabilities compared to directly installed skills?
+'Native' agent skills can be presented through the user agent, bundled with subagents, etc. Do MCP-surfaced skills lose capabilities compared to directly installed skills? This question also ties into a more general topic about context-as-resources discoverability and standardization of client host behavior — it's not just a skills-specific framing question.
 
-**Community input:**
-
-> "The only slight concern I have is the idea that there are still 'first class skills' (skills that agents recognize as skills, can be presented as skills through the user agent, can be bundled with subagents, etc) and these sort of 'skills as context' approaches where the agent can certainly discover and ingest the skills data, but possibly with some differences compared to how they would apply first class skills." — [Bob Dickinson](https://github.com/TeamSparkAI)
-
-> "I don't like creating dichotomy between first-class skills and skills as context, because pretty much everything an MCP server exposes is context. Skills-as-resources is much more accurate." — [Peder Holdgaard Pedersen](https://github.com/PederHP)
+For more community input on this topic see: (approaches.md#design-principles)
 
 ## 3. Should server.instructions be extended for richer content?
 
 Or is the separation between "primitive server" and "skill that uses the primitive" the right abstraction?
-
-**Community input:**
-
-> "I would caution against seeing skills as too tightly coupled with tools. Not all skills need to be related to the tools on a server — or even client-side tool use at all. This is especially true for agents that use very broad tools or heavily reliant on code interpreter and similar meta-tools." — [Peder Holdgaard Pedersen](https://github.com/PederHP)
 
 ## 4. How should skills relate to multiple servers?
 

--- a/docs/open-questions.md
+++ b/docs/open-questions.md
@@ -96,4 +96,4 @@ Skills already work as simple files that agents load directly. Adding MCP to the
 
 >  "Skills can be benefit from MCP Servers as an "official" distribution channel from an organizations. Also, Skills _can be_ dependendent on the specific tools _only_ available on the MCP server they are distributed with. I see Skills and MCP are complementary to each other." — [Yu Yi](https://github.com/erain)
 
-> "MCP servers are most useful as an appendage of skills, like `scripts/` are. That also naturally answers the question of multi-server skills." — [Jonathan Hefner](https://github.com/jmhefner)
+> "MCP servers are most useful as an appendage of skills, like `scripts/` are. That also naturally answers the question of multi-server skills." — [Jonathan Hefner](https://github.com/jonathanhefner)

--- a/docs/open-questions.md
+++ b/docs/open-questions.md
@@ -84,6 +84,8 @@ Note: Some apps like Claude Code have started to indicate in the skill frontmatt
 
 > "If the conclusion is 'just use resources', I am fine with that direction too — but then we should standardize a way to identify and list workflow resources as 'skills' so clients can reliably surface them (otherwise we are back to out-of-band conventions)." — [sebthom](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2167#issuecomment-3824771018)
 
+See also [Approaches](approaches.md) for more notes on using resources.
+
 ## 13. What is the optimal relationship between skills and MCP?
 
 Skills already work as simple files that agents load directly. Adding MCP to the process should provide clear value beyond what standalone skills already offer.
@@ -93,3 +95,5 @@ Skills already work as simple files that agents load directly. Adding MCP to the
 > "Skills are simple files that agents can load directly even if they don't have any MCP servers connected. Adding MCP to the process only for that would be over complicating something that already works well... the question becomes 'what is the optimal relationship between skills and MCP?'" — [Cliff Hall](https://github.com/cliffhall)
 
 >  "Skills can be benefit from MCP Servers as an "official" distribution channel from an organizations. Also, Skills _can be_ dependendent on the specific tools _only_ available on the MCP server they are distributed with. I see Skills and MCP are complementary to each other." — [Yu Yi](https://github.com/erain)
+
+> "MCP servers are most useful as an appendage of skills, like `scripts/` are. That also naturally answers the question of multi-server skills." — [Jonathan Hefner](https://github.com/jmhefner)

--- a/docs/problem-statement.md
+++ b/docs/problem-statement.md
@@ -13,7 +13,7 @@
 
 Skills discoverability is a specific instance of a more general MCP challenge: context-as-resources discoverability and standardization of client host behavior around non-tool primitives. The ecosystem has largely optimized for tools, and patterns for how clients discover and consume other forms of context — including skills — remain underdeveloped. Solutions in this space are likely to have implications beyond skills alone.
 
-MCP's value for skills isn't just distribution, it's the interaction model. MCP defines app, human, and assistant roles, giving skills a built-in framework for control model decisions (who sees the content, who decides when it loads). This makes MCP a natural complement to skills as a delivery channel for workflow instructions.
+MCP's value for skills goes beyond distribution; it provides an interaction model. MCP defines app, human, and assistant roles, giving skills a built-in framework for control model decisions (who sees the content, who decides when it loads). This makes MCP a natural complement to skills as a delivery channel for workflow instructions.
 
 ## Key Use Cases
 

--- a/docs/problem-statement.md
+++ b/docs/problem-statement.md
@@ -9,6 +9,10 @@
 - **No discovery mechanism** — users installing MCP servers from a registry don't know if there's a corresponding skill they should also install
 - **Multi-server orchestration** — skills may need to coordinate tools from multiple servers, which doesn't fit the single-server instruction model
 
+## Broader Context
+
+Skills discoverability is a specific instance of a more general MCP challenge: context-as-resources discoverability and standardization of client host behavior around non-tool primitives. The ecosystem has largely optimized for tools, and patterns for how clients discover and consume other forms of context — including skills — remain underdeveloped. Solutions in this space are likely to have implications beyond skills alone.
+
 ## Key Use Cases
 
 See [use-cases.md](use-cases.md) for detailed use cases and community input. In summary:

--- a/docs/problem-statement.md
+++ b/docs/problem-statement.md
@@ -13,6 +13,8 @@
 
 Skills discoverability is a specific instance of a more general MCP challenge: context-as-resources discoverability and standardization of client host behavior around non-tool primitives. The ecosystem has largely optimized for tools, and patterns for how clients discover and consume other forms of context — including skills — remain underdeveloped. Solutions in this space are likely to have implications beyond skills alone.
 
+MCP's value for skills isn't just distribution, it's the interaction model. MCP defines app, human, and assistant roles, giving skills a built-in framework for control model decisions (who sees the content, who decides when it loads). This makes MCP a natural complement to skills as a delivery channel for workflow instructions.
+
 ## Key Use Cases
 
 See [use-cases.md](use-cases.md) for detailed use cases and community input. In summary:

--- a/docs/related-work.md
+++ b/docs/related-work.md
@@ -9,11 +9,13 @@
 
 ## Implementations
 
+Original implementations from external repositories (example implementations in this repo will be added to `examples` folder):
+
 | Implementation | Author | URL | Notes |
 | :--- | :--- | :--- | :--- |
-| skilljack-mcp | Ola Hungerford | [github.com/olaservo/skilljack-mcp](https://github.com/olaservo/skilljack-mcp) | Skills as tools with dynamic updates |
-| mcpGraph skill | Bob Dickinson | [github.com/TeamSparkAI/mcpGraph](https://github.com/TeamSparkAI/mcpGraph) | 875+ line skill for graph orchestration |
-| skills-over-mcp | Keith Groves | [github.com/keithagroves/skills-over-mcp](https://github.com/keithagroves/skills-over-mcp) | Example using skills with current MCP primitives |
+| skilljack-mcp | Ola Hungerford | [github.com/olaservo/skilljack-mcp](https://github.com/olaservo/skilljack-mcp) | Skills as MCP tools, resources, prompts with dynamic updates |
+| mcpGraph skill | Bob Dickinson | [github.com/TeamSparkAI/mcpGraph](https://github.com/TeamSparkAI/mcpGraph) | Complex skill example for graph orchestration |
+| skills-over-mcp | Keith Groves | [github.com/keithagroves/skills-over-mcp](https://github.com/keithagroves/skills-over-mcp) | Example using skills as MCP resources with current MCP primitives |
 | chrome-devtools-mcp | Anthropic | [github.com/anthropics/anthropic-quickstarts/…/chrome-devtools-mcp](https://github.com/anthropics/anthropic-quickstarts/tree/main/mcp-servers/chrome-devtools-mcp) | Real-world example: `skills/` folder requires separate install path |
 | NimbleBrain skills repo | NimbleBrain | [github.com/NimbleBrainInc/skills](https://github.com/NimbleBrainInc/skills) | Monorepo with `.skill` artifact format |
 | NimbleBrain registry | NimbleBrain | [registry.nimbletools.ai](https://registry.nimbletools.ai/) | Registry with skill metadata support |

--- a/docs/related-work.md
+++ b/docs/related-work.md
@@ -24,6 +24,7 @@ Original implementations from external repositories (example implementations in 
 | mcp-cli | philschmid | [github.com/philschmid/mcp-cli](https://github.com/philschmid/mcp-cli) | Wraps MCP servers as CLI for progressive disclosure |
 | mcp-execution | bug-ops | [github.com/bug-ops/mcp-execution](https://github.com/bug-ops/mcp-execution) | Compiles MCP servers into skill packages |
 | Astronomer agents | Kaxil Naik | [github.com/astronomer/agents](https://github.com/astronomer/agents) | Skills distribution via MCP for Apache Airflow |
+| my-cool-proxy | karashiiro | [github.com/karashiiro/my-cool-proxy](https://github.com/karashiiro/my-cool-proxy) | MCP gateway server with skills as resources via Lua scripts |
 
 ## External Resources
 


### PR DESCRIPTION
## Summary

- **Enhanced design principles** with community insights on skills-as-context, discoverability and ecosystem complexity challenges, and the principle that primitive choice should follow from use case
- **Renamed Approach 3** from "Skills as Tools" to "Skills as Tools and/or Resources" to reflect that skills can also be exposed as resources (e.g. `skill://...`), with `my-cool-proxy` added as a reference implementation
- **Updated problem statement** with clarification on MCP's role in the skills interaction model
- **Improved related work descriptions** with clearer implementation details

## Test plan

- [ ] Verify design principles reflect community consensus
- [ ] Check that all community attribution links are correct