### PR TITLE
Update meeting notes and discussion links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 This Interest Group welcomes contributions from anyone interested in skills distribution over MCP. You can participate by:
 
 - Joining discussions in the [#skills-over-mcp-ig Discord channel](https://discord.com/channels/1358869848138059966/1464745826629976084) (info on joining the Discord server [here](https://modelcontextprotocol.io/community/communication#discord))
-- Opening or commenting on GitHub Discussions in this repo
+- Opening or commenting on [GitHub Discussions](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/categories/meeting-notes-skills-over-mcp-ig) in the main MCP repo
 - Sharing experimental findings from your own implementations
 - Contributing to documentation and pattern evaluation
 
@@ -14,12 +14,12 @@ This Interest Group welcomes contributions from anyone interested in skills dist
 | Channel | Purpose | Response Expectation |
 | :--- | :--- | :--- |
 | [Discord #skills-over-mcp-ig](https://discord.com/channels/1358869848138059966/1464745826629976084) | Quick questions, coordination, async discussion | Best effort |
-| GitHub Discussions | Long-form technical proposals, experimental findings | Weekly triage |
+| [GitHub Discussions](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/categories/meeting-notes-skills-over-mcp-ig) | Meeting notes, long-form technical proposals, experimental findings | Weekly triage |
 | This repository | Living reference for approaches, findings, and decisions | Updated after meetings |
 
 ## Meetings
 
-*To be scheduled* — likely biweekly working sessions once the group establishes momentum.
+[Meeting notes](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/categories/meeting-notes-skills-over-mcp-ig) are published in the main MCP repo discussions. Future meetings will be scheduled and scheduling surveys posted in the [#skills-over-mcp-ig Discord channel](https://discord.com/channels/1358869848138059966/1464745826629976084).
 
 Meeting norms:
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ See [problem-statement.md](docs/problem-statement.md) for full details.
 | [Open Questions](docs/open-questions.md) | Unresolved questions with community input |
 | [Experimental Findings](docs/experimental-findings.md) | Results from implementations and testing |
 | [Related Work](docs/related-work.md) | SEPs, implementations, and external resources |
+| [Meeting Notes](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/categories/meeting-notes-skills-over-mcp-ig) | Published after each working session |
 | [Contributing](CONTRIBUTING.md) | How to participate |
 
 ## Stakeholder Groups

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This Interest Group explores how "[agent skills](https://agentskills.io/)" (rich
 - **Approving spec changes:** This IG does not have authority to approve protocol changes; recommendations flow through the SEP process
 - **Registry schema decisions:** Coordinate with Registry WG; this IG explores requirements but doesn't own the schema
 - **Client implementation mandates:** We can document patterns but not require specific client behavior
+- **Plugin/bundle packaging:** Some use cases surface a broader need for installable bundles (skills + servers + subagents + configuration as a single artifact). How to solve for this is out of scope.
 
 ## Problem Statement
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ This Interest Group explores how "[agent skills](https://agentskills.io/)" (rich
 - **Approving spec changes:** This IG does not have authority to approve protocol changes; recommendations flow through the SEP process
 - **Registry schema decisions:** Coordinate with Registry WG; this IG explores requirements but doesn't own the schema
 - **Client implementation mandates:** We can document patterns but not require specific client behavior
-- **Plugin/bundle packaging:** Some use cases surface a broader need for installable bundles (skills + servers + subagents + configuration as a single artifact). How to solve for this is out of scope.
 
 ## Problem Statement
 


### PR DESCRIPTION
## Summary
- Update CONTRIBUTING.md and README.md to point meeting notes and discussions to the [main MCP repo discussions category](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/categories/meeting-notes-skills-over-mcp-ig) instead of this IG repo
- Replace the "To be scheduled" meetings placeholder with the actual meeting notes link and note that future meetings/surveys are posted in the Discord channel
- Add a Meeting Notes row to the README Repository Contents table

## Test plan
- [ ] Verify all discussion links resolve to the correct category
- [ ] Verify Discord channel links are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)