### PR TITLE
Add decision log with ADR-lite format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,16 @@ When adding quotes or input from community discussions:
 - Link to the original source (Discord thread, GitHub comment, etc.) where possible
 - Present input as blockquotes to distinguish it from editorial content
 
+### Decision Log
+
+Significant decisions made during meetings or through async discussion should be recorded in [docs/decisions.md](docs/decisions.md) using the ADR-lite format defined there. A decision is worth logging when it:
+
+- Chooses one approach over alternatives
+- Sets or changes the group's scope
+- Establishes a convention or coordination mechanism
+
+Add a new entry after the meeting where the decision was made or when rough consensus is reached asynchronously. Include context, the decision itself, rationale, and links to relevant issues, PRs, or discussion threads.
+
 ### Filing Issues
 
 Use GitHub Issues for:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ See [problem-statement.md](docs/problem-statement.md) for full details.
 | [Open Questions](docs/open-questions.md) | Unresolved questions with community input |
 | [Experimental Findings](docs/experimental-findings.md) | Results from implementations and testing |
 | [Related Work](docs/related-work.md) | SEPs, implementations, and external resources |
+| [Decision Log](docs/decisions.md) | Record of key decisions with context and rationale |
 | [Meeting Notes](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/categories/meeting-notes-skills-over-mcp-ig) | Published after each working session |
 | [Contributing](CONTRIBUTING.md) | How to participate |
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -6,19 +6,19 @@ For background on the ADR format, see [adr.github.io](https://adr.github.io/).
 
 ---
 
-### 2026-02-14: Focus on skills-as-instructors over skills-as-helpers for MCP
+### 2026-02-14: Skills served over MCP use the instructor format
 
 **Status:** Accepted
 
-**Context:** The inaugural meeting surfaced a key distinction between two models: skills-as-instructors (text that teaches agents how to use MCP tools) and skills-as-helpers (scripts/code that execute locally). The group needed to decide which model to prioritize for skills served over MCP.
+**Context:** The inaugural meeting surfaced a key distinction between two models: skills-as-instructors (structured markdown content served to agents) and skills-as-helpers (scripts/code that execute locally). The group needed to decide which model to prioritize for skills served over MCP. Subsequent discussion in Discord and the Feb 26 office hours broadened the scope beyond "teaching agents to use tools" specifically.
 
-**Decision:** Skills served over MCP should focus on the instructor model -- teaching agents to use tools correctly -- rather than the helper model that executes arbitrary local code.
+**Decision:** Skills served over MCP use the instructor format (structured markdown content), with the convention being agnostic about whether skills reference server tools, external tools, or general knowledge. The helper model (executing arbitrary local code) is out of scope for MCP-served skills.
 
 **Rationale:** Helper-style skills that require local code execution already have existing distribution mechanisms (repos, npx, etc.) and don't need MCP as a transport. Instructor-style skills are more portable across remote and local MCP servers, easier to security-vet (static instructional content vs. arbitrary code), and align better with MCP's role as a context protocol. Dynamically served code-execution skills were flagged as unlikely to pass security review for registry listing.
 
 **References:**
 - [Feb 13 meeting notes](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/2248) (Key Decisions & Agreements)
-- [Problem Statement](docs/problem-statement.md)
+- [Problem Statement](problem-statement.md)
 
 ---
 
@@ -43,7 +43,7 @@ For background on the ADR format, see [adr.github.io](https://adr.github.io/).
 
 **Context:** The group needed to decide whether to bring external implementations (reference repos, SEPs, related projects) into this repository or link to them externally.
 
-**Decision:** Document results from implementations in `docs/experimental-findings.md` and link to external repos and resources in `docs/related-work.md`, rather than forking or vendoring external code.
+**Decision:** Document results from implementations in `experimental-findings.md` and link to external repos and resources in `related-work.md`, rather than forking or vendoring external code.
 
 **Rationale:** This avoids duplication and maintenance burden, keeps the repo focused on the IG's exploratory documentation, and lets external projects evolve independently. The pattern of findings + references is working well for the group's needs.
 
@@ -82,7 +82,7 @@ For background on the ADR format, see [adr.github.io](https://adr.github.io/).
 **References:**
 - [Issue #14](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/14)
 - [PR #17](https://github.com/modelcontextprotocol/experimental-ext-skills/pull/17)
-- [Approaches doc](docs/approaches.md)
+- [Approaches doc](approaches.md)
 
 ---
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,0 +1,101 @@
+# Decision Log
+
+This document records significant decisions made by the Skills Over MCP Interest Group, using an ADR-lite (Architecture Decision Record) format. It serves as a transparent, auditable trace of the group's reasoning over time.
+
+For background on the ADR format, see [adr.github.io](https://adr.github.io/).
+
+---
+
+### 2026-02-14: Focus on skills-as-instructors over skills-as-helpers for MCP
+
+**Status:** Accepted
+
+**Context:** The inaugural meeting surfaced a key distinction between two models: skills-as-instructors (text that teaches agents how to use MCP tools) and skills-as-helpers (scripts/code that execute locally). The group needed to decide which model to prioritize for skills served over MCP.
+
+**Decision:** Skills served over MCP should focus on the instructor model -- teaching agents to use tools correctly -- rather than the helper model that executes arbitrary local code.
+
+**Rationale:** Helper-style skills that require local code execution already have existing distribution mechanisms (repos, npx, etc.) and don't need MCP as a transport. Instructor-style skills are more portable across remote and local MCP servers, easier to security-vet (static instructional content vs. arbitrary code), and align better with MCP's role as a context protocol. Dynamically served code-execution skills were flagged as unlikely to pass security review for registry listing.
+
+**References:**
+- [Feb 13 meeting notes](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/2248) (Key Decisions & Agreements)
+- [Problem Statement](docs/problem-statement.md)
+
+---
+
+### 2026-02-14: Keep docs as markdown in-repo rather than publish as a website
+
+**Status:** Accepted
+
+**Context:** The question arose whether the IG should publish docs using a solution like Mintlify or keep them as markdown files in the repository.
+
+**Decision:** Keep documentation as markdown files in the repository.
+
+**Rationale:** The markdown-in-repo approach is working well for the IG's current needs. It keeps the contribution barrier low (just edit markdown and submit a PR), avoids introducing additional tooling and infrastructure, and is sufficient for the group's size and documentation complexity. Can be revisited if the group grows or docs become harder to navigate.
+
+**References:**
+- [Issue #7](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/7)
+
+---
+
+### 2026-02-14: Reference external implementations rather than fork them
+
+**Status:** Accepted
+
+**Context:** The group needed to decide whether to bring external implementations (reference repos, SEPs, related projects) into this repository or link to them externally.
+
+**Decision:** Document results from implementations in `docs/experimental-findings.md` and link to external repos and resources in `docs/related-work.md`, rather than forking or vendoring external code.
+
+**Rationale:** This avoids duplication and maintenance burden, keeps the repo focused on the IG's exploratory documentation, and lets external projects evolve independently. The pattern of findings + references is working well for the group's needs.
+
+**References:**
+- [Issue #8](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/8)
+
+---
+
+### 2026-02-21: Coordinate with Agent Skills spec via their Discussions
+
+**Status:** Accepted
+
+**Context:** The IG needed a communication channel with the [Agent Skills spec](https://agentskills.io/) maintainers to align on proposals, share findings, and avoid divergence. The spec repo initially had no contributing guide.
+
+**Decision:** Use [Discussions in the agentskills/agentskills repo](https://github.com/agentskills/agentskills/discussions) as the primary channel for topics that intersect both groups.
+
+**Rationale:** The Agent Skills spec maintainers established a [contributing guide](https://github.com/agentskills/agentskills/blob/main/CONTRIBUTING.md) directing public discussion to their Discussions area. Using their preferred channel respects their governance model and provides a single, visible place for cross-project coordination rather than fragmenting discussion across Discord, GitHub Issues, and other venues.
+
+**References:**
+- [Issue #12](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/12)
+- [PR #28](https://github.com/modelcontextprotocol/experimental-ext-skills/pull/28)
+- [Agent Skills contributing guide](https://github.com/agentskills/agentskills/blob/main/CONTRIBUTING.md)
+
+---
+
+### 2026-02-21: Add skills-as-resources as an explored approach
+
+**Status:** Accepted
+
+**Context:** Community input (via [Issue #14](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/14)) argued that MCP Resources are a natural fit for serving skill content, and that adding a new primitive when an existing one could work would add unnecessary complexity to the ecosystem.
+
+**Decision:** Incorporate skills-as-resources as an explicit approach in the IG's exploration, updating Approach 3 from "Skills as Tools" to "Skills as Tools and/or Resources" and adding design principles around minimizing ecosystem complexity.
+
+**Rationale:** Resources already have URI-based addressability, existing tooling for fetching, and a subscription model for updates. Using existing primitives rather than introducing new ones reduces ecosystem complexity -- a concern the community has vocally raised. The `skill://` URI scheme also gives skills a natural way to reference each other.
+
+**References:**
+- [Issue #14](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/14)
+- [PR #17](https://github.com/modelcontextprotocol/experimental-ext-skills/pull/17)
+- [Approaches doc](docs/approaches.md)
+
+---
+
+### 2026-02-26: Prioritize skills-as-resources with client helper tools
+
+**Status:** Accepted
+
+**Context:** The Feb 26 office hours discussed the skills-as-resources reference implementation ([PR #16](https://github.com/modelcontextprotocol/experimental-ext-skills/pull/16)) and whether the group should focus on workarounds for today's clients or the ideal client-supported approach.
+
+**Decision:** Focus on the skills-as-resources approach using client helper tools (e.g., a built-in `read_resource` tool on the client side and an SDK-level `list_skill_uris()` method). Workaround implementations (e.g., skills in tool descriptions) remain in the repo as comparison baselines but are clearly separated in intent.
+
+**Rationale:** Rather than having each server ship its own `load_skill` tool, clients should support model-driven resource loading directly. This is a relatively small lift for clients (compared to features like elicitation or sampling) and avoids duplicate approaches across servers. Experimental SDK changes will allow clients and models to load skill resources more consistently, which could also unlock other Resource use cases beyond skills. The plan is to partner with client implementors to test once the extension is ready.
+
+**References:**
+- [Feb 26 office hours notes](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/2316) (Section 1)
+- [PR #16](https://github.com/modelcontextprotocol/experimental-ext-skills/pull/16)


### PR DESCRIPTION
Closes #49

Creates `docs/decisions.md` using an ADR-lite format, seeded with 6 historical decisions reconstructed from closed issues and meeting notes:

1. **Focus on skills-as-instructors** over skills-as-helpers for MCP (Feb 13 meeting)
2. **Keep docs as markdown in-repo** rather than publish as a website (#7)
3. **Reference external implementations** rather than fork them (#8)
4. **Coordinate with Agent Skills spec** via their Discussions (#12, PR #28)
5. **Add skills-as-resources** as an explored approach (#14, PR #17)
6. **Prioritize skills-as-resources with client helper tools** (Feb 26 office hours)

Each entry includes context, decision, rationale, and references.

Also:
- Updates CONTRIBUTING.md with guidance on when to add decision log entries
- Adds the decision log to the README documents table