### PR TITLE
Rename section 'Open SEPs and Proposals' to 'SEPs and Proposals'

### DIFF
--- a/docs/related-work.md
+++ b/docs/related-work.md
@@ -1,6 +1,6 @@
 # Related Work
 
-## Open SEPs and Proposals
+## SEPs and Proposals
 
 | Proposal | Venue | Description |
 | :--- | :--- | :--- |


### PR DESCRIPTION
Making a small tweak since not all listed SEPs are still open, keeping listed for visibility.