### PR TITLE
docs: add ADR for filesystem as host-side implementation detail

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -137,7 +137,7 @@ For background on the ADR format, see [adr.github.io](https://adr.github.io/).
 
 ---
 
-### 2026-04-18: Filesystem is a host-side implementation detail
+### 2026-04-19: Filesystem is a host-side implementation detail
 
 **Status:** Proposed
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -152,5 +152,5 @@ For background on the ADR format, see [adr.github.io](https://adr.github.io/).
 **Rationale:** The value of filesystem-agnosticism is a consumer-side guarantee: a skill author writes one skill and knows it will run on any conformant host, from a cloud-code CLI with disk access to a stateless remote agent. Requiring MCP-served skills to work without a filesystem preserves this guarantee. Permitting host-side materialization preserves the use cases Peter flagged on March 24 (local server example from Jake, performance optimization for large skills, filesystem-native tooling integration). Requiring unified resolution semantics closes the gap that would otherwise make materialization a behavior-divergence source. The SEP's "Hosts: Unified Treatment" section already aspires to this at SHOULD level; this ADR promotes the semantic requirement to MUST while keeping the implementation a host choice.
 
 **References:**
-- Archive distribution ADR — companion decision on packaging (forthcoming)
+- [PR #83](https://github.com/modelcontextprotocol/experimental-ext-skills/pull/83) — companion ADR on archive distribution
 - [SEP PR #69](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/69), "Hosts: Unified Treatment of Filesystem and MCP Skills" section

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -134,3 +134,23 @@ For background on the ADR format, see [adr.github.io](https://adr.github.io/).
 - [PR #2586](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2586) — charter conversion (merged 2026-04-16)
 - [Charter](https://modelcontextprotocol.io/community/skills-over-mcp/charter)
 - [Group governance](https://modelcontextprotocol.io/community/working-interest-groups)
+
+---
+
+### 2026-04-18: Filesystem is a host-side implementation detail
+
+**Status:** Proposed
+
+**Context:** Previous meetings surfaced an open question: whether the Skills Extension SEP should require, forbid, or remain silent on a local filesystem as a host capability. The SEP as drafted is de facto filesystem-agnostic (resources are URI-addressable, `read_resource` is the recommended loading path) but does not state this as a normative requirement, leaving skill authors without a portability guarantee and hosts without clear scope.
+
+**Decision:** The Skills Extension SEP treats the filesystem as a host-side implementation detail. Specifically:
+
+- A skill served over MCP MUST function correctly on hosts that have no access to a local filesystem. Skill content, supporting files, and relative-path resolution MUST be expressible entirely through MCP resource operations.
+- Hosts MAY materialize skill resources into a local filesystem as a performance or compatibility optimization.
+- Regardless of materialization strategy, relative-path resolution within a skill MUST produce the same result as URI-based resolution. A skill that references `references/guide.md` from its `SKILL.md` resolves to the same content whether the host loads it from disk or from `resources/read` on the originating server.
+
+**Rationale:** The value of filesystem-agnosticism is a consumer-side guarantee: a skill author writes one skill and knows it will run on any conformant host, from a cloud-code CLI with disk access to a stateless remote agent. Requiring MCP-served skills to work without a filesystem preserves this guarantee. Permitting host-side materialization preserves the use cases Peter flagged on March 24 (local server example from Jake, performance optimization for large skills, filesystem-native tooling integration). Requiring unified resolution semantics closes the gap that would otherwise make materialization a behavior-divergence source. The SEP's "Hosts: Unified Treatment" section already aspires to this at SHOULD level; this ADR promotes the semantic requirement to MUST while keeping the implementation a host choice.
+
+**References:**
+- Archive distribution ADR — companion decision on packaging (forthcoming)
+- [SEP PR #69](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/69), "Hosts: Unified Treatment of Filesystem and MCP Skills" section


### PR DESCRIPTION
## Summary
- Adds a proposed ADR (2026-04-19) recording that the Skills Extension SEP treats the filesystem as a host-side implementation detail.
- Skills served over MCP MUST function on hosts without a local filesystem; hosts MAY materialize resources as an optimization; relative-path resolution MUST produce the same result either way.
- Promotes the "Hosts: Unified Treatment" semantic requirement from SHOULD to MUST while keeping materialization a host choice.

## Note
The SEP has included the "Hosts: Unified Treatment" section and filesystem-parity relative-path resolution since PR #69's first commit (2026-03-17). This ADR formalizes a stance the draft SEP has carried for ~a month, promoting the semantic requirement from SHOULD to MUST.

## Related
- Companion ADR on archive distribution: #83

## Notes
- Status is **Proposed** pending WG discussion.

## Test plan
- [ ] Verify ADR renders correctly in `docs/decisions.md`
- [ ] WG review of wording, especially the MUST/MAY boundaries