### PR TITLE
docs: link SEP-2640 across repo and tidy Related Work table

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 **Project board:** [Skills Over MCP WG](https://github.com/orgs/modelcontextprotocol/projects/38/views/1)
 **Meeting notes:** [Skills Over MCP WG discussions](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/categories/meeting-notes-skills-over-mcp-wg)
 **Discord:** [#skills-over-mcp-wg](https://discord.com/channels/1358869848138059966/1464745826629976084)
+**Open work:** [Pull requests](https://github.com/modelcontextprotocol/experimental-ext-skills/pulls) — proposals, decisions, implementations, and other in-flight contributions welcome.
 
 ## Why Skills Over MCP?
 

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ See [problem-statement.md](docs/problem-statement.md) for full details.
 | [Why Skills Over MCP?](docs/why-and-when.md) | Value proposition and decision guide |
 | [Use Cases](docs/use-cases.md) | Key use cases driving this work |
 | [Approaches](docs/approaches.md) | Approaches being explored (not mutually exclusive) |
+| [SEP-2640: Skills Extension](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640) | Proposal to serve skills over MCP via the Resources primitive. Original working draft: [`docs/sep-draft-skills-extension.md`](docs/sep-draft-skills-extension.md). Comments and review happen on the PR. |
 | [Open Questions](docs/open-questions.md) | Unresolved questions with community input (see also [issues](https://github.com/modelcontextprotocol/experimental-ext-skills/issues) and [meeting notes](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/categories/meeting-notes-skills-over-mcp-wg)) |
 | [Experimental Findings](docs/experimental-findings.md) | Results from implementations and testing |
 | [Related Work](docs/related-work.md) | SEPs, implementations, and external resources |
 | [Decision Log](docs/decisions.md) | Record of key decisions with context and rationale |
-| [SEP-2640: Skills Extension](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640) | Proposal to serve skills over MCP via the Resources primitive. Original working draft: [`docs/sep-draft-skills-extension.md`](docs/sep-draft-skills-extension.md). Comments and review happen on the PR. |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ See [problem-statement.md](docs/problem-statement.md) for full details.
 | [Experimental Findings](docs/experimental-findings.md) | Results from implementations and testing |
 | [Related Work](docs/related-work.md) | SEPs, implementations, and external resources |
 | [Decision Log](docs/decisions.md) | Record of key decisions with context and rationale |
-| [SEP-2640: Skills Extension](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640) | Proposal to serve skills over MCP via the Resources primitive and `skill://` URI scheme. Original working draft: [`docs/sep-draft-skills-extension.md`](docs/sep-draft-skills-extension.md). Comments and review happen on the PR. |
+| [SEP-2640: Skills Extension](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640) | Proposal to serve skills over MCP via the Resources primitive. Original working draft: [`docs/sep-draft-skills-extension.md`](docs/sep-draft-skills-extension.md). Comments and review happen on the PR. |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ See [problem-statement.md](docs/problem-statement.md) for full details.
 | [Why Skills Over MCP?](docs/why-and-when.md) | Value proposition and decision guide |
 | [Use Cases](docs/use-cases.md) | Key use cases driving this work |
 | [Approaches](docs/approaches.md) | Approaches being explored (not mutually exclusive) |
-| [Open Questions](docs/open-questions.md) | Unresolved questions with community input |
+| [Open Questions](docs/open-questions.md) | Unresolved questions with community input (see also [issues](https://github.com/modelcontextprotocol/experimental-ext-skills/issues) and [meeting notes](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/categories/meeting-notes-skills-over-mcp-wg)) |
 | [Experimental Findings](docs/experimental-findings.md) | Results from implementations and testing |
 | [Related Work](docs/related-work.md) | SEPs, implementations, and external resources |
 | [Decision Log](docs/decisions.md) | Record of key decisions with context and rationale |

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ See [problem-statement.md](docs/problem-statement.md) for full details.
 | [Experimental Findings](docs/experimental-findings.md) | Results from implementations and testing |
 | [Related Work](docs/related-work.md) | SEPs, implementations, and external resources |
 | [Decision Log](docs/decisions.md) | Record of key decisions with context and rationale |
-| [Skills Extension SEP — PR #2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640) | Proposal to serve skills over MCP via the Resources primitive and `skill://` URI scheme. Original working draft: [`docs/sep-draft-skills-extension.md`](docs/sep-draft-skills-extension.md). Comments and review happen on the PR. |
+| [SEP-2640: Skills Extension](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640) | Proposal to serve skills over MCP via the Resources primitive and `skill://` URI scheme. Original working draft: [`docs/sep-draft-skills-extension.md`](docs/sep-draft-skills-extension.md). Comments and review happen on the PR. |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ See [problem-statement.md](docs/problem-statement.md) for full details.
 | [Experimental Findings](docs/experimental-findings.md) | Results from implementations and testing |
 | [Related Work](docs/related-work.md) | SEPs, implementations, and external resources |
 | [Decision Log](docs/decisions.md) | Record of key decisions with context and rationale |
-| [Draft SEP: Skills Extension](docs/sep-draft-skills-extension.md) | Pre-submission SEP draft defining the `skill://` resource convention |
+| [Skills Extension SEP — PR #2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640) | Proposal to serve skills over MCP via the Resources primitive and `skill://` URI scheme. Original working draft: [`docs/sep-draft-skills-extension.md`](docs/sep-draft-skills-extension.md). Comments and review happen on the PR. |
 
 ## Contributing
 

--- a/docs/approaches.md
+++ b/docs/approaches.md
@@ -17,7 +17,7 @@ Several design considerations are emerging from community discussion:
 
 The approaches below span a spectrum. At one end, skills become a first-class MCP primitive with dedicated protocol methods (Approach 1). At the other, existing primitives are used with documented conventions (Approach 6). A key question for this WG is whether convention can prove patterns before standardization — or whether the ecosystem needs protocol-level support to achieve reliable interoperability. These are not mutually exclusive; convention work can inform and de-risk a future protocol extension.
 
-**Current status:** The convention approach (Approach 6) was pursued and quickly evolved into a formal Extensions Track SEP ([#69](https://github.com/modelcontextprotocol/experimental-ext-skills/pull/69)), building on convergence across 4+ independent `skill://` implementations. The SEP uses existing Resources primitives with zero protocol changes, positioning it between pure convention and a new primitive. See [#75](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/75) for tracking. Submitted to the MCP spec as [PR #2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640) on 2026-04-23.
+**Current status:** The convention approach (Approach 6) was pursued and quickly evolved into a formal Extensions Track SEP ([#69](https://github.com/modelcontextprotocol/experimental-ext-skills/pull/69)), building on convergence across 4+ independent `skill://` implementations. The SEP uses existing Resources primitives with zero protocol changes, positioning it between pure convention and a new primitive. See [#75](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/75) for tracking. Submitted to the MCP spec as [SEP-2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640) on 2026-04-23.
 
 ## 1. Skills as Distinct MCP Primitives
 
@@ -35,7 +35,7 @@ Add Agent Skills as a first-class, discoverable primitive in MCP. A skill is a n
 - Progressive disclosure: clients load skill summaries at startup, fetch full instructions on demand
 - Mapping to existing SKILL.md format
 
-**Status:** Draft, seeking sponsor.
+**Status:** Closed without merge on 2026-02-24; did not find a sponsor. See [SEP-2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640) for this WG's alternative Resources-based approach.
 
 **Community input:**
 

--- a/docs/approaches.md
+++ b/docs/approaches.md
@@ -17,7 +17,7 @@ Several design considerations are emerging from community discussion:
 
 The approaches below span a spectrum. At one end, skills become a first-class MCP primitive with dedicated protocol methods (Approach 1). At the other, existing primitives are used with documented conventions (Approach 6). A key question for this WG is whether convention can prove patterns before standardization — or whether the ecosystem needs protocol-level support to achieve reliable interoperability. These are not mutually exclusive; convention work can inform and de-risk a future protocol extension.
 
-**Current status:** The convention approach (Approach 6) was pursued and quickly evolved into a formal Extensions Track SEP ([#69](https://github.com/modelcontextprotocol/experimental-ext-skills/pull/69)), building on convergence across 4+ independent `skill://` implementations. The SEP uses existing Resources primitives with zero protocol changes, positioning it between pure convention and a new primitive. See [#75](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/75) for tracking.
+**Current status:** The convention approach (Approach 6) was pursued and quickly evolved into a formal Extensions Track SEP ([#69](https://github.com/modelcontextprotocol/experimental-ext-skills/pull/69)), building on convergence across 4+ independent `skill://` implementations. The SEP uses existing Resources primitives with zero protocol changes, positioning it between pure convention and a new primitive. See [#75](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/75) for tracking. Submitted to the MCP spec as [PR #2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640) on 2026-04-23.
 
 ## 1. Skills as Distinct MCP Primitives
 

--- a/docs/approaches.md
+++ b/docs/approaches.md
@@ -35,7 +35,7 @@ Add Agent Skills as a first-class, discoverable primitive in MCP. A skill is a n
 - Progressive disclosure: clients load skill summaries at startup, fetch full instructions on demand
 - Mapping to existing SKILL.md format
 
-**Status:** Closed without merge on 2026-02-24; did not find a sponsor. See [SEP-2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640) for this WG's alternative Resources-based approach.
+**Status:** Closed on 2026-02-24 after the WG decided to first explore a convention-based approach using existing primitives. See [SEP-2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640) for the resulting Resources-based proposal.
 
 **Community input:**
 

--- a/docs/open-questions.md
+++ b/docs/open-questions.md
@@ -121,7 +121,7 @@ See also [Approaches](approaches.md) for more notes on using resources.
 
 ## 13. What is the optimal relationship between skills and MCP?
 
-> **Tracked in:** [#75](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/75) — Skills Extension SEP (submitted as [PR #2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640))
+> **Tracked in:** [#75](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/75) — Skills Extension SEP (submitted as [SEP-2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640))
 > **See also:** [#47](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/47) — Create evaluation matrix mapping approaches to requirements
 
 Skills already work as simple files that agents load directly. Adding MCP to the process should provide clear value beyond what standalone skills already offer.

--- a/docs/open-questions.md
+++ b/docs/open-questions.md
@@ -121,7 +121,7 @@ See also [Approaches](approaches.md) for more notes on using resources.
 
 ## 13. What is the optimal relationship between skills and MCP?
 
-> **Tracked in:** [#75](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/75) — Skills Extension SEP
+> **Tracked in:** [#75](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/75) — Skills Extension SEP (submitted as [PR #2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640))
 > **See also:** [#47](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/47) — Create evaluation matrix mapping approaches to requirements
 
 Skills already work as simple files that agents load directly. Adding MCP to the process should provide clear value beyond what standalone skills already offer.

--- a/docs/related-work.md
+++ b/docs/related-work.md
@@ -4,11 +4,11 @@
 
 | Proposal | Venue | Description |
 | :--- | :--- | :--- |
-| [SEP-2076](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2076) | MCP Spec | Agent Skills as a first-class MCP primitive |
 | [PR #2527](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2527) | MCP Spec | Recommend clients expose resource read to models — prerequisite for the resources-based skills approach |
 | [PR #2640 (Skills Extension SEP)](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640) | MCP Spec | This WG's proposed extension: skills served over MCP using the Resources primitive and `skill://` URI scheme ([working draft](sep-draft-skills-extension.md)) |
 | [skills.json format proposal](https://github.com/modelcontextprotocol/registry/discussions/895) | MCP Registry | Skills metadata in registry schema |
 | ~~[SEP-2093](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2093)~~ | MCP Spec | ~~Resource Contents Metadata and Capabilities: scoped `resources/list`, per-resource capabilities, `resources/metadata` endpoint~~ — **rejected** ([labeled upstream](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2093)) |
+| ~~[SEP-2076](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2076)~~ | MCP Spec | ~~Agent Skills as a first-class MCP primitive~~ — **closed** (2026-02-24, without merge) |
 
 ## Working Group Member Implementations
 

--- a/docs/related-work.md
+++ b/docs/related-work.md
@@ -5,10 +5,10 @@
 | Proposal | Venue | Description |
 | :--- | :--- | :--- |
 | [SEP-2076](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2076) | MCP Spec | Agent Skills as a first-class MCP primitive |
-| ~~[SEP-2093](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2093)~~ | MCP Spec | ~~Resource Contents Metadata and Capabilities: scoped `resources/list`, per-resource capabilities, `resources/metadata` endpoint~~ — **rejected** ([labeled upstream](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2093)) |
 | [PR #2527](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2527) | MCP Spec | Recommend clients expose resource read to models — prerequisite for the resources-based skills approach |
 | [PR #2640 (Skills Extension SEP)](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640) | MCP Spec | This WG's proposed extension: skills served over MCP using the Resources primitive and `skill://` URI scheme ([working draft](sep-draft-skills-extension.md)) |
 | [skills.json format proposal](https://github.com/modelcontextprotocol/registry/discussions/895) | MCP Registry | Skills metadata in registry schema |
+| ~~[SEP-2093](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2093)~~ | MCP Spec | ~~Resource Contents Metadata and Capabilities: scoped `resources/list`, per-resource capabilities, `resources/metadata` endpoint~~ — **rejected** ([labeled upstream](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2093)) |
 
 ## Working Group Member Implementations
 

--- a/docs/related-work.md
+++ b/docs/related-work.md
@@ -5,8 +5,9 @@
 | Proposal | Venue | Description |
 | :--- | :--- | :--- |
 | [SEP-2076](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2076) | MCP Spec | Agent Skills as a first-class MCP primitive |
-| [SEP-2093](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2093) | MCP Spec | Resource Contents Metadata and Capabilities: scoped `resources/list`, per-resource capabilities, `resources/metadata` endpoint |
+| ~~[SEP-2093](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2093)~~ | MCP Spec | ~~Resource Contents Metadata and Capabilities: scoped `resources/list`, per-resource capabilities, `resources/metadata` endpoint~~ — **rejected** ([labeled upstream](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2093)) |
 | [PR #2527](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2527) | MCP Spec | Recommend clients expose resource read to models — prerequisite for the resources-based skills approach |
+| [PR #2640 (Skills Extension SEP)](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640) | MCP Spec | This WG's proposed extension: skills served over MCP using the Resources primitive and `skill://` URI scheme ([working draft](sep-draft-skills-extension.md)) |
 | [skills.json format proposal](https://github.com/modelcontextprotocol/registry/discussions/895) | MCP Registry | Skills metadata in registry schema |
 
 ## Working Group Member Implementations

--- a/docs/related-work.md
+++ b/docs/related-work.md
@@ -4,8 +4,8 @@
 
 | Proposal | Venue | Description |
 | :--- | :--- | :--- |
-| [PR #2527](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2527) | MCP Spec | Recommend clients expose resource read to models — prerequisite for the resources-based skills approach |
 | [SEP-2640 (Skills Extension)](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640) | MCP Spec | This WG's proposed extension: skills served over MCP using the Resources primitive and `skill://` URI scheme ([working draft](sep-draft-skills-extension.md)) |
+| [PR #2527](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2527) | MCP Spec | Recommend clients expose resource read to models — prerequisite for the resources-based skills approach |
 | [skills.json format proposal](https://github.com/modelcontextprotocol/registry/discussions/895) | MCP Registry | Skills metadata in registry schema |
 | ~~[SEP-2093](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2093)~~ | MCP Spec | ~~Resource Contents Metadata and Capabilities: scoped `resources/list`, per-resource capabilities, `resources/metadata` endpoint~~ — **rejected** ([labeled upstream](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2093)) |
 | ~~[SEP-2076](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2076)~~ | MCP Spec | ~~Agent Skills as a first-class MCP primitive~~ — **closed** (2026-02-24, without merge) |

--- a/docs/related-work.md
+++ b/docs/related-work.md
@@ -5,7 +5,7 @@
 | Proposal | Venue | Description |
 | :--- | :--- | :--- |
 | [PR #2527](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2527) | MCP Spec | Recommend clients expose resource read to models — prerequisite for the resources-based skills approach |
-| [PR #2640 (Skills Extension SEP)](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640) | MCP Spec | This WG's proposed extension: skills served over MCP using the Resources primitive and `skill://` URI scheme ([working draft](sep-draft-skills-extension.md)) |
+| [SEP-2640 (Skills Extension)](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640) | MCP Spec | This WG's proposed extension: skills served over MCP using the Resources primitive and `skill://` URI scheme ([working draft](sep-draft-skills-extension.md)) |
 | [skills.json format proposal](https://github.com/modelcontextprotocol/registry/discussions/895) | MCP Registry | Skills metadata in registry schema |
 | ~~[SEP-2093](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2093)~~ | MCP Spec | ~~Resource Contents Metadata and Capabilities: scoped `resources/list`, per-resource capabilities, `resources/metadata` endpoint~~ — **rejected** ([labeled upstream](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2093)) |
 | ~~[SEP-2076](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2076)~~ | MCP Spec | ~~Agent Skills as a first-class MCP primitive~~ — **closed** (2026-02-24, without merge) |

--- a/docs/sep-draft-skills-extension.md
+++ b/docs/sep-draft-skills-extension.md
@@ -1,14 +1,14 @@
 # SEP-0000: Skills Extension
 
-- **Status**: Draft (pre-submission)
+- **Status**: Draft (submitted)
 - **Type**: Extensions Track
 - **Created**: 2026-03-17
-- **Author(s)**: Skills Over MCP Interest Group
+- **Author(s)**: Skills Over MCP Working Group
 - **Sponsor**: _(seeking)_
 - **Extension Identifier**: `io.modelcontextprotocol/skills`
-- **PR**: _(to be assigned on submission)_
+- **PR**: [#2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640)
 
-> This document is a pre-submission draft maintained by the [Skills Over MCP Interest Group](https://github.com/modelcontextprotocol/experimental-ext-skills). It has not yet been submitted to the main MCP repository. Discussion welcome via [GitHub Issues](https://github.com/modelcontextprotocol/experimental-ext-skills/issues) or [Discord #skills-over-mcp-ig](https://discord.com/channels/1358869848138059966/1464745826629976084).
+> **NOTE:** This SEP has been submitted to the main MCP repository as [PR #2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640); future review and comments happen there. This repo-local copy is the working draft maintained by the [Skills Over MCP Working Group](https://github.com/modelcontextprotocol/experimental-ext-skills) and may be revised as upstream review feedback is incorporated. Additional discussion welcome via [GitHub Issues](https://github.com/modelcontextprotocol/experimental-ext-skills/issues) or [Discord #skills-over-mcp-wg](https://discord.com/channels/1358869848138059966/1464745826629976084).
 
 ## Abstract
 

--- a/docs/sep-draft-skills-extension.md
+++ b/docs/sep-draft-skills-extension.md
@@ -1,4 +1,4 @@
-# SEP-0000: Skills Extension
+# SEP-2640: Skills Extension
 
 - **Status**: Draft (submitted)
 - **Type**: Extensions Track
@@ -8,7 +8,7 @@
 - **Extension Identifier**: `io.modelcontextprotocol/skills`
 - **PR**: [#2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640)
 
-> **NOTE:** This SEP has been submitted to the main MCP repository as [PR #2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640); future review and comments happen there. This repo-local copy is the working draft maintained by the [Skills Over MCP Working Group](https://github.com/modelcontextprotocol/experimental-ext-skills) and may be revised as upstream review feedback is incorporated. Additional discussion welcome via [GitHub Issues](https://github.com/modelcontextprotocol/experimental-ext-skills/issues) or [Discord #skills-over-mcp-wg](https://discord.com/channels/1358869848138059966/1464745826629976084).
+> **NOTE:** This SEP has been submitted to the main MCP repository as [SEP-2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640); future review and comments happen there. This repo-local copy is the working draft maintained by the [Skills Over MCP Working Group](https://github.com/modelcontextprotocol/experimental-ext-skills) and may be revised as upstream review feedback is incorporated. Additional discussion welcome via [GitHub Issues](https://github.com/modelcontextprotocol/experimental-ext-skills/issues) or [Discord #skills-over-mcp-wg](https://discord.com/channels/1358869848138059966/1464745826629976084).
 
 ## Abstract
 

--- a/docs/skill-uri-scheme.md
+++ b/docs/skill-uri-scheme.md
@@ -3,7 +3,7 @@
 > Proposed convention for identifying skill resources over MCP.
 
 **Issue:** [#44](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/44)
-**Status:** Incorporated into the draft [Skills Extension SEP](https://github.com/modelcontextprotocol/experimental-ext-skills/pull/69), now submitted to the MCP spec as [PR #2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640). This survey informed the SEP's URI scheme design; see also [PR #70](https://github.com/modelcontextprotocol/experimental-ext-skills/pull/70) for subsequent refinements (multi-segment paths, path-name decoupling).
+**Status:** Incorporated into the draft [Skills Extension SEP](https://github.com/modelcontextprotocol/experimental-ext-skills/pull/69), now submitted to the MCP spec as [SEP-2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640). This survey informed the SEP's URI scheme design; see also [PR #70](https://github.com/modelcontextprotocol/experimental-ext-skills/pull/70) for subsequent refinements (multi-segment paths, path-name decoupling).
 
 ---
 

--- a/docs/skill-uri-scheme.md
+++ b/docs/skill-uri-scheme.md
@@ -3,7 +3,7 @@
 > Proposed convention for identifying skill resources over MCP.
 
 **Issue:** [#44](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/44)
-**Status:** Incorporated into the draft [Skills Extension SEP](https://github.com/modelcontextprotocol/experimental-ext-skills/pull/69). This survey informed the SEP's URI scheme design; see also [PR #70](https://github.com/modelcontextprotocol/experimental-ext-skills/pull/70) for subsequent refinements (multi-segment paths, path-name decoupling).
+**Status:** Incorporated into the draft [Skills Extension SEP](https://github.com/modelcontextprotocol/experimental-ext-skills/pull/69), now submitted to the MCP spec as [PR #2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640). This survey informed the SEP's URI scheme design; see also [PR #70](https://github.com/modelcontextprotocol/experimental-ext-skills/pull/70) for subsequent refinements (multi-segment paths, path-name decoupling).
 
 ---
 


### PR DESCRIPTION
## Summary

- Wires the Skills Extension SEP's upstream submission ([SEP-2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640)) into this repo: SEP doc header, README Repository Contents, `related-work.md`, `approaches.md`, `open-questions.md`, `skill-uri-scheme.md`. Renames the in-repo draft from `SEP-0000` to `SEP-2640` per the [SEP naming convention](https://modelcontextprotocol.io/community/sep-guidelines) (SEP number = PR number).
- Reorders the README Repository Contents table so SEP-2640 sits after Approaches (framing → options → proposal → supporting material), and the `related-work.md` SEPs table so SEP-2640 leads. Strikes and moves inactive proposals (SEP-2093 rejected, SEP-2076 closed) to the bottom, with updated Approach 1 status to reflect SEP-2076's closure after the WG pivoted to the convention-based approach.
- Adds an **Open work** link to the README header pointing to open PRs, so readers see that alternative proposals, decisions, and implementations are still welcome. Also inlines issue/meeting-notes links in the Open Questions row.

## Test plan

- [ ] Render README and each touched doc on GitHub; visually check tables, strikethroughs, and link targets.
- [ ] Click through SEP-2640 / PR #2527 / SEP-2093 / SEP-2076 / #75 / #69 / #70 / issues / meeting-notes links to confirm they resolve.
- [ ] Confirm SEP-2640 appears on the [WG project board](https://github.com/orgs/modelcontextprotocol/projects/38) with Status = In review.