### PR TITLE
docs: fix chrome-devtools-mcp links

### DIFF
--- a/docs/related-work.md
+++ b/docs/related-work.md
@@ -52,7 +52,7 @@ Projects that illustrate the problem space or use adjacent patterns.
 
 | Project | Author | URL | Notes |
 | :--- | :--- | :--- | :--- |
-| chrome-devtools-mcp | Anthropic | [github.com/anthropics/anthropic-quickstarts/…/chrome-devtools-mcp](https://github.com/anthropics/anthropic-quickstarts/tree/main/mcp-servers/chrome-devtools-mcp) | Real-world example of the problem: `skills/` folder requires separate install path |
+| chrome-devtools-mcp | Google (ChromeDevTools) | [github.com/ChromeDevTools/chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp) | Real-world example of the problem: `skills/` folder requires separate install path |
 | Strands Agents MCP server | AWS | [github.com/strands-agents/mcp-server](https://github.com/strands-agents/mcp-server/) | Docs-as-MCP: TF-IDF search + doc fetch |
 | AWS MCP server | AWS | [docs.aws.amazon.com/aws-mcp/…](https://docs.aws.amazon.com/aws-mcp/latest/userguide/understanding-mcp-server-tools.html) | `retrieve_agent_sop` (skills) + `call_aws` (tool) |
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -58,7 +58,7 @@ Servers that are difficult or impossible to use effectively without an accompany
 
 > "Clients of the registry presumably understand MCP, but there is no guarantee that they understand skills. So if it is going to be hard for an agent to use the server without the 'skill' then doesn't it make sense for the MCP server to contain all the instructions necessary to use it?" — [Cliff Hall](https://github.com/cliffhall)
 
-**Example:** [chrome-devtools-mcp](https://github.com/anthropics/anthropic-quickstarts/tree/main/mcp-servers/chrome-devtools-mcp) ships with a skills/ folder that requires a separate install path from the MCP server itself.
+**Example:** [chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp) ships with a skills/ folder that requires a separate install path from the MCP server itself.
 
 ## 6. Skill Versioning and Updates
 

--- a/docs/why-and-when.md
+++ b/docs/why-and-when.md
@@ -26,7 +26,7 @@ See [NimbleBrain findings](experimental-findings.md#nimblebrain-skill-resource-c
 
 Users installing MCP servers from a registry today don't know if there's a companion skill they should also install. Skills over MCP creates a natural discovery path: connect to a server, discover its skills through the same interface. No separate search, no documentation hunting, no hoping someone mentioned the skill in a README.
 
-See [Use Case 5: Server-Skill Pairing](use-cases.md#5-server-skill-pairing) for examples including Anthropic's [chrome-devtools-mcp](https://github.com/anthropics/anthropic-quickstarts/tree/main/mcp-servers/chrome-devtools-mcp), which ships a `skills/` folder that requires a separate install path from the server itself.
+See [Use Case 5: Server-Skill Pairing](use-cases.md#5-server-skill-pairing) for examples including the Chrome DevTools team's [chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp), which ships a `skills/` folder that requires a separate install path from the server itself.
 
 ### Dynamic Updates Without Reinstall
 


### PR DESCRIPTION
The chrome-devtools-mcp links pointed to `anthropics/anthropic-quickstarts`, but the project actually lives at [ChromeDevTools/chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp). Updates 3 docs and corrects the author attribution from Anthropic to Google (ChromeDevTools).