### PR TITLE
docs: add experimental findings template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,7 @@ Outputs include:
 
 When adding experimental findings or new approaches:
 
+- Start from the [experimental findings template](docs/findings-template.md) when adding a new entry to [docs/experimental-findings.md](docs/experimental-findings.md)
 - Include enough detail for others to reproduce or evaluate
 - Note which clients and servers were tested
 - Be explicit about what worked, what didn't, and what remains untested

--- a/docs/experimental-findings.md
+++ b/docs/experimental-findings.md
@@ -1,6 +1,6 @@
 # Experimental Findings
 
-> **Contributing findings?** See [#50](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/50) for the contribution template proposal.
+> **Contributing findings?** Use the [experimental findings template](findings-template.md) when adding a new entry.
 
 ## McpGraph: Skills in MCP Server Repo
 

--- a/docs/findings-template.md
+++ b/docs/findings-template.md
@@ -1,0 +1,68 @@
+# Experimental Findings Template
+
+Use this template when adding a new entry to [experimental-findings.md](experimental-findings.md). Keep the level of detail high enough that another implementer can reproduce the setup or compare the result with a different client/server pair.
+
+## Title
+
+Briefly name the project, approach, or experiment.
+
+## Summary
+
+Describe the experiment in one or two paragraphs:
+
+- What was tested
+- Why it matters for skills over MCP
+- Which approach or design question it informs
+
+## Implementation
+
+Link to the relevant implementation artifacts:
+
+- Repository:
+- Pull request, branch, or commit:
+- Skill files:
+- MCP server/client files:
+- Related issue or discussion:
+
+## Environment
+
+List the concrete setup used for the experiment:
+
+- MCP client:
+- MCP server or framework:
+- Model:
+- Runtime or language version:
+- Operating system:
+- Other relevant dependencies:
+
+## Findings
+
+Separate observations from conclusions:
+
+- What worked:
+- What did not work:
+- What was surprising:
+- What remains untested:
+
+## Reproduction Notes
+
+Include enough detail for another contributor to rerun or inspect the experiment:
+
+```sh
+# commands, config snippets, or setup notes
+```
+
+## Community Input
+
+Attribute any external input that shaped the finding:
+
+> Quoted feedback goes here.
+
+- Source:
+- Contributor:
+
+## Open Questions
+
+List follow-up questions or decisions the working group should consider:
+
+- 


### PR DESCRIPTION
## Summary
- add a reusable template for experimental findings
- link the template from the findings document and contributing guide

Fixes #50

## Verification
- git diff --check