### PR TITLE
docs(sep): sync _meta reverse-domain prefix sentence from SEP-2640

### DIFF
--- a/docs/sep-draft-skills-extension.md
+++ b/docs/sep-draft-skills-extension.md
@@ -87,7 +87,7 @@ For each `skill://<skill-path>/SKILL.md` resource:
 - `name` SHOULD be set from the `name` field of the `SKILL.md` YAML frontmatter. By the path constraint above, this will equal the final segment of `<skill-path>`.
 - `description` SHOULD be set from the `description` field of the `SKILL.md` YAML frontmatter.
 
-Servers MAY expose additional frontmatter fields via the resource's `_meta` object. Other files in the skill use the `mimeType` appropriate to their content.
+Servers MAY expose additional frontmatter fields via the resource's `_meta` object. When `_meta` keys are used for skill resources, implementations SHOULD use the `io.modelcontextprotocol.skills/` reverse-domain prefix. Other files in the skill use the `mimeType` appropriate to their content.
 
 ### Discovery
 


### PR DESCRIPTION
Syncs the repo-local working draft with the submitted SEP.

The Resource Metadata section in `docs/sep-draft-skills-extension.md` omits the sentence recommending the `io.modelcontextprotocol.skills/` reverse-domain prefix for skill-resource `_meta` keys. That sentence is present in the submitted [SEP-2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640) (`seps/2640-skills-extension.md`):

> Servers MAY expose additional frontmatter fields via the resource's `_meta` object. **When `_meta` keys are used for skill resources, implementations SHOULD use the `io.modelcontextprotocol.skills/` reverse-domain prefix.** Other files in the skill use the `mimeType` appropriate to their content.

This brings the working-draft copy back in line. Surfaced while comparing a PHP SDK implementation against the draft ([discussion](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640#issuecomment-4622668503)) — the draft and the PR had drifted on this one sentence.
