### PR TITLE
Add findings template and retrofit existing entries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,10 @@ This Working Group welcomes contributions from anyone interested in skills distr
 - Sharing experimental findings from your own implementations
 - Contributing to documentation and pattern evaluation
 
+## Contributing Findings
+
+If you have experimental results from implementing skills-over-MCP, add them to `docs/experimental-findings.md` using the [findings template](docs/findings-template.md). This keeps entries consistent and ensures nothing important is omitted.
+
 ## Communication Channels
 
 | Channel | Purpose | Response Expectation |

--- a/docs/experimental-findings.md
+++ b/docs/experimental-findings.md
@@ -33,11 +33,29 @@
 
 ## Skilljack MCP
 
-**Repo:** [olaservo/skilljack-mcp](https://github.com/olaservo/skilljack-mcp)
+**Date:** Early 2026 (approximate)
 
-Loads skills into tool descriptions. Uses dynamic tool updates to keep the skills manifest current.
+**Implementation:**
+- **Repo:** [olaservo/skilljack-mcp](https://github.com/olaservo/skilljack-mcp)
+- **Author:** olaservo
 
-Example eval approach and observations here: https://github.com/olaservo/skilljack-mcp/blob/main/evals/README.md
+**Approach tested:** Skills-as-tools (dynamic tool descriptions)
+
+**Setup:**
+- **Clients tested:** Not documented
+- **Models tested:** Not documented
+- **Configuration notes:** Skills loaded into tool descriptions via dynamic tool updates
+
+**What was tested:** Whether loading skill content into tool descriptions and using dynamic tool updates to keep the skills manifest current improves skill adherence.
+
+**Results:**
+- **What worked:** Dynamic tool updates keep the skills manifest current
+- **What didn't:** Not documented (see [eval README](https://github.com/olaservo/skilljack-mcp/blob/main/evals/README.md) for details)
+- **Surprises:** Not documented
+
+**Requirements addressed:** Skill delivery via tool descriptions (see `docs/requirements.md`)
+
+**Limitations:** Detailed results are in the repo's eval README, not summarized here. Setup and model details not documented.
 
 ## FastMCP 3.0 Skills Support
 

--- a/docs/experimental-findings.md
+++ b/docs/experimental-findings.md
@@ -6,23 +6,30 @@
 
 ## McpGraph: Skills in MCP Server Repo
 
-**Repo:** [TeamSparkAI/mcpGraph](https://github.com/TeamSparkAI/mcpGraph)
-**Skill:** [mcpgraphtoolkit/SKILL.md](https://github.com/TeamSparkAI/mcpGraph/blob/main/skills/mcpgraphtoolkit/SKILL.md) (875+ lines)
+**Date:** Early 2026 (approximate)
 
-Bob Dickinson built a standalone SKILL.md file that lives in the same repo as the MCP server, but they weren't formally connected. The skill instructs agents on building directed graphs of MCP nodes to orchestrate tool calls.
+**Implementation:**
+- **Repo:** [TeamSparkAI/mcpGraph](https://github.com/TeamSparkAI/mcpGraph)
+- **Author:** Bob Dickinson
+- **Skill file(s):** [mcpgraphtoolkit/SKILL.md](https://github.com/TeamSparkAI/mcpGraph/blob/main/skills/mcpgraphtoolkit/SKILL.md) (875+ lines)
 
-**Findings:**
+**Approach tested:** Skills colocated with MCP server (see `docs/approaches.md`)
 
-- Claude ignored the SKILL.md initially, even when the skill and server had similar descriptions
-- Claude would fail at using the server tools a couple times, then read the skill and succeed
-- Expected Claude to start with the skill ("I know how to do X") before the server ("I do X"), but it didn't
+**Setup:**
+- **Clients tested:** Claude (specific client not documented)
+- **Models tested:** Claude (specific model not documented)
+- **Configuration notes:** SKILL.md lives in the same repo as the MCP server, not formally connected
 
-**Resolution:** Added a server instruction telling the agent to read the SKILL.md before using the tool. That one change caused Claude to reliably read the skill first.
+**What was tested:** Whether agents read and follow skill instructions when they're colocated with the server but not explicitly linked. Tested discovery and loading behavior.
 
-**Remaining concerns:**
+**Results:**
+- **What worked:** After adding a server instruction telling the agent to read the SKILL.md before using the tool, Claude reliably read the skill first
+- **What didn't:** Claude initially ignored the SKILL.md even when the skill and server had similar descriptions. Expected Claude to start with the skill ("I know how to do X") before the server ("I do X"), but it didn't. Claude would fail at using server tools, then read the skill and succeed.
+- **Surprises:** A single server instruction was enough to fix the loading order problem
 
-- This workaround works for 1:1 skill-to-server case, but doesn't solve discovery — users installing from a registry don't know to also install the skill
-- Distinguishes between "skill required to make the server work at all" vs. "skill that orchestrates tools you could use without it" — potentially different solutions needed
+**Requirements addressed:** Skill discovery and loading behavior (see `docs/requirements.md`)
+
+**Limitations:** This workaround works for 1:1 skill-to-server case only. Does not solve discovery for users installing from a registry. The distinction between "skill required to make the server work at all" vs. "skill that orchestrates tools you could use without it" may require different solutions.
 
 ## Skilljack MCP
 

--- a/docs/findings-template.md
+++ b/docs/findings-template.md
@@ -1,0 +1,42 @@
+# Findings Template
+
+Use this template when adding experimental findings to `docs/experimental-findings.md`. Copy the section below and fill in each field.
+
+---
+
+## [Project Name]: [Brief Description]
+
+**Date:** YYYY-MM-DD (or approximate timeframe)
+
+**Implementation:**
+- **Repo:** [link to repository]
+- **Author:** [name/handle]
+- **Skill file(s):** [path(s) to SKILL.md or equivalent]
+
+**Approach tested:** [Which approach from `docs/approaches.md` does this map to?]
+
+**Setup:**
+- **Clients tested:** [e.g., Claude Desktop, Cline, custom client]
+- **Models tested:** [e.g., Claude Sonnet 4, GPT-4o]
+- **Configuration notes:** [any relevant setup details]
+
+**What was tested:** [Specific scenarios or behaviors evaluated]
+
+**Results:**
+- **What worked:** [observations]
+- **What didn't:** [observations]
+- **Surprises:** [unexpected findings]
+
+**Requirements addressed:** [Which requirements from `docs/requirements.md` does this provide evidence for?]
+
+**Limitations:** [What remains untested, uncertain, or context-dependent]
+
+---
+
+## How to Contribute Findings
+
+1. Copy the template above
+2. Fill in all fields (use "N/A" or "unknown" where something doesn't apply rather than omitting)
+3. Add your findings section to `docs/experimental-findings.md` following the existing section order
+4. Open a PR with the title `findings: [project name]`
+5. Reference any related issues or discussions


### PR DESCRIPTION
## What

Addresses #50

- Adds `docs/findings-template.md` with a structured template for contributing experimental findings
- Updates `CONTRIBUTING.md` with a "Contributing Findings" section linking to the template
- Retrofits the **McpGraph** and **Skilljack MCP** entries in `docs/experimental-findings.md` to demonstrate the template format

## Why

As noted in #50, existing findings entries vary in structure. A consistent template makes entries comparable and ensures nothing important is omitted (setup details, model versions, limitations, etc.).

## Template fields

The template covers all fields from #50:
- Implementation (name, repo, author, skill files)
- Approach tested (mapped to approaches.md)
- Setup (clients, models, config notes)
- What was tested
- Results (worked / didn't / surprises)
- Requirements addressed
- Limitations
- Date

The retrofitted McpGraph and Skilljack entries show how the template works with real data. Where original entries lacked information (e.g., specific model versions), I marked those as "not documented" rather than omitting the field.