### PR TITLE
Add Node.js example implementation of Skills-over-MCP

### DIFF
--- a/examples/node-skills-server/README.md
+++ b/examples/node-skills-server/README.md
@@ -1,0 +1,72 @@
+# Node.js Skills-over-MCP example server
+
+A minimal, complete reference implementation of [SEP-2640 (Skills
+Extension)](../../docs/sep-draft-skills-extension.md): serves [Agent
+Skills](https://agentskills.io/) over MCP using the Resources primitive and
+the `skill://` URI scheme.
+
+## What it does
+
+- Discovers skills from a local directory (default: `./skills`; override with
+  `SKILLS_DIR`). A skill is any directory containing a `SKILL.md`.
+- Parses each `SKILL.md`'s YAML frontmatter (`name`, `description`) with
+  [`gray-matter`](https://www.npmjs.com/package/gray-matter).
+- Validates the SEP-2640 constraints: the frontmatter `name` must match the
+  skill directory's own name, must use only lowercase letters/digits/hyphens,
+  and skills must not nest (a `SKILL.md` inside another skill's directory is
+  a startup error, not a silent mis-resolution).
+- Exposes every file in a skill directory as an MCP resource at
+  `skill://<skill-path>/<file-path>`, served via standard `resources/list`
+  and `resources/read`.
+- Exposes `skill://index.json`, the well-known discovery index.
+- Declares the `io.modelcontextprotocol/skills` extension capability in its
+  `initialize` response (see the note in `server.js` about the current SDK's
+  typing gap for this).
+
+Scope: text-based skill files. Binary assets would use the `blob`
+(base64) resource-content field instead of `text` — not implemented here, to
+keep the example focused on the parts of the spec every skill server needs.
+
+## Running it
+
+```bash
+npm install
+npm start
+```
+
+This starts an MCP server over stdio. Connect any MCP client (or the sample
+`skills/` in this directory, containing `git-workflow` and `pdf-processing`
+— the same examples used in the SEP's own resource-mapping table).
+
+Point it at a different skill directory:
+
+```bash
+SKILLS_DIR=/path/to/your/skills npm start
+```
+
+## Trying it with the MCP Inspector
+
+```bash
+npx @modelcontextprotocol/inspector node server.js
+```
+
+Then, in the Inspector UI: `resources/list` shows `skill://index.json` plus
+every skill file; `resources/read` on `skill://git-workflow/SKILL.md` returns
+the skill's content; `resources/read` on
+`skill://pdf-processing/references/FORMS.md` demonstrates a nested reference
+file resolving correctly.
+
+## Adding your own skills
+
+Add a directory under `skills/` whose name matches the `name` field in its
+`SKILL.md` frontmatter:
+
+```
+skills/
+  my-skill/
+    SKILL.md          # required: name + description frontmatter
+    references/
+      GUIDE.md         # optional: any additional files
+```
+
+No server code changes needed — skills are discovered at startup.

--- a/examples/node-skills-server/package.json
+++ b/examples/node-skills-server/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "node-skills-server-example",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Minimal reference implementation of SEP-2640 (Skills Extension) — serves Agent Skills over MCP via the Resources primitive.",
+  "type": "module",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "gray-matter": "^4.0.3"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/examples/node-skills-server/server.js
+++ b/examples/node-skills-server/server.js
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+/**
+ * Minimal reference implementation of SEP-2640 (Skills Extension) for MCP.
+ *
+ * Discovers skills from a local directory (default: ./skills, override with
+ * SKILLS_DIR), parses each SKILL.md's YAML frontmatter, and serves them as
+ * MCP resources under the skill:// URI scheme -- see:
+ *   https://github.com/modelcontextprotocol/experimental-ext-skills/blob/main/docs/sep-draft-skills-extension.md
+ *
+ * This targets the CURRENT SEP-2640 draft (resources-only transport binding).
+ * An earlier sketch of this example (see the tracking issue) proposed
+ * exposing skill "activation" as tools/list + tools/call; the ratified
+ * design settled on Resources alone (see the SEP's own "Why Resources
+ * Instead of a New Primitive?" rationale) -- this implementation follows
+ * that, not the earlier sketch.
+ *
+ * Scope: text-based skill files (SKILL.md + markdown/text references), the
+ * shape covered by every example in the SEP itself. Binary assets would use
+ * the `blob` (base64) resource-content field instead of `text` -- not
+ * implemented here to keep the example focused.
+ */
+
+// Uses the low-level `Server` class rather than the SDK's higher-level
+// `McpServer` (which the SDK's own JSDoc marks preferred for typical cases,
+// reserving `Server` for "advanced use cases"). This example is exactly that
+// case: it declares a not-yet-typed capability (`extensions`, SEP-2133) and
+// resolves a custom multi-segment URI scheme (skill-path and file-path are
+// each independently multi-segment) that doesn't map cleanly onto a single
+// ResourceTemplate. The explicit request handlers below also show the raw
+// resources/list and resources/read shapes directly, which is useful for
+// implementers porting this pattern to other SDKs/languages.
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  ListResourcesRequestSchema,
+  ReadResourceRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import matter from "gray-matter";
+import { readdir, readFile } from "node:fs/promises";
+import { join, relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = fileURLToPath(new URL(".", import.meta.url));
+const SKILLS_ROOT = process.env.SKILLS_DIR
+  ? join(process.cwd(), process.env.SKILLS_DIR)
+  : join(HERE, "skills");
+
+// A skill's `name` (SEP-2640: "the final <skill-path> segment MUST equal the
+// skill's `name`") is constrained to the Agent Skills naming rules: lowercase
+// letters, digits, and hyphens only.
+const VALID_SKILL_NAME = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+function posix(p) {
+  return p.split(sep).join("/");
+}
+
+async function walkFiles(dir) {
+  const out = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...(await walkFiles(full)));
+    else out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Discover skills under SKILLS_ROOT. A skill is any directory containing a
+ * SKILL.md; the skill-path is that directory's path relative to SKILLS_ROOT.
+ * Returns a Map<skillPath, { name, description, files: Map<relFilePath, absPath> }>.
+ */
+async function loadSkills(root) {
+  const allFiles = await walkFiles(root);
+  const skillMdFiles = allFiles.filter((f) => f.endsWith(`${sep}SKILL.md`));
+  const skillDirs = skillMdFiles.map((f) => f.slice(0, -`${sep}SKILL.md`.length));
+
+  // SEP-2640: "A SKILL.md MUST NOT appear in any descendant directory of a
+  // skill" -- skills do not nest. Catch this early with a clear error rather
+  // than silently mis-resolving skill:// URIs later.
+  for (const a of skillDirs) {
+    for (const b of skillDirs) {
+      if (a !== b && b.startsWith(a + sep)) {
+        throw new Error(
+          `invalid skill layout: "${posix(relative(root, b))}" is nested inside ` +
+            `"${posix(relative(root, a))}" -- SEP-2640 skills must not nest`,
+        );
+      }
+    }
+  }
+
+  const skills = new Map();
+  for (const mdPath of skillMdFiles) {
+    const skillDir = mdPath.slice(0, -`${sep}SKILL.md`.length);
+    const skillPath = posix(relative(root, skillDir));
+    const raw = await readFile(mdPath, "utf8");
+    const { data } = matter(raw);
+
+    if (!data.name || !data.description) {
+      console.error(`skipping "${skillPath}": SKILL.md frontmatter missing required name/description`);
+      continue;
+    }
+    if (!VALID_SKILL_NAME.test(data.name)) {
+      console.error(`skipping "${skillPath}": frontmatter name "${data.name}" is not lowercase-letters/digits/hyphens`);
+      continue;
+    }
+    const dirLeaf = skillPath.split("/").pop();
+    if (data.name !== dirLeaf) {
+      console.error(
+        `skipping "${skillPath}": frontmatter name "${data.name}" must equal the final ` +
+          `path segment "${dirLeaf}" (SEP-2640 requires these to match)`,
+      );
+      continue;
+    }
+
+    const files = new Map();
+    for (const f of allFiles.filter((f) => f === mdPath || f.startsWith(skillDir + sep))) {
+      files.set(posix(relative(skillDir, f)), f);
+    }
+    skills.set(skillPath, { name: data.name, description: data.description, files });
+  }
+  return skills;
+}
+
+function mimeTypeFor(relFilePath) {
+  if (relFilePath.endsWith(".md")) return "text/markdown";
+  if (relFilePath.endsWith(".json")) return "application/json";
+  return "text/plain";
+}
+
+/** skill://index.json content -- the Agent Skills discovery-index shape (SEP-2640 §Enumeration). */
+function buildIndex(skills) {
+  return {
+    $schema: "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+    skills: [...skills.entries()].map(([skillPath, skill]) => ({
+      name: skill.name,
+      type: "skill-md",
+      description: skill.description,
+      url: `skill://${skillPath}/SKILL.md`,
+    })),
+  };
+}
+
+/** Resolve a skill:// URI to its absolute file path, or null if not found. */
+function resolveSkillUri(skills, uri) {
+  if (!uri.startsWith("skill://")) return null;
+  const path = uri.slice("skill://".length);
+  for (const [skillPath, skill] of skills) {
+    const prefix = `${skillPath}/`;
+    if (path.startsWith(prefix)) {
+      const relFile = path.slice(prefix.length);
+      const abs = skill.files.get(relFile);
+      if (abs) return { abs, mimeType: mimeTypeFor(relFile) };
+    }
+  }
+  return null;
+}
+
+async function main() {
+  const skills = await loadSkills(SKILLS_ROOT);
+
+  const server = new Server(
+    { name: "node-skills-server-example", version: "0.1.0" },
+    {
+      capabilities: {
+        resources: {},
+        // SEP-2640 capability declaration (io.modelcontextprotocol/skills).
+        // As of @modelcontextprotocol/sdk 1.29.0, ServerCapabilities has no
+        // `extensions` field yet (SEP-2133 hasn't landed in the SDK's types) --
+        // this still round-trips correctly since the SDK does not validate or
+        // strip unknown capability keys at runtime, it just forwards whatever
+        // object is passed here. Update this once the SDK adds first-class
+        // extensions support.
+        extensions: {
+          "io.modelcontextprotocol/skills": {},
+        },
+      },
+    },
+  );
+
+  server.setRequestHandler(ListResourcesRequestSchema, async () => {
+    const resources = [
+      {
+        uri: "skill://index.json",
+        name: "index.json",
+        mimeType: "application/json",
+        description: "Index of skills served by this server (SEP-2640 discovery).",
+      },
+    ];
+    for (const [skillPath, skill] of skills) {
+      for (const [relFile] of skill.files) {
+        resources.push({
+          uri: `skill://${skillPath}/${relFile}`,
+          name: relFile === "SKILL.md" ? skill.name : relFile,
+          mimeType: mimeTypeFor(relFile),
+          ...(relFile === "SKILL.md" ? { description: skill.description } : {}),
+        });
+      }
+    }
+    return { resources };
+  });
+
+  server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+    const { uri } = request.params;
+
+    if (uri === "skill://index.json") {
+      return {
+        contents: [
+          { uri, mimeType: "application/json", text: JSON.stringify(buildIndex(skills), null, 2) },
+        ],
+      };
+    }
+
+    const resolved = resolveSkillUri(skills, uri);
+    if (!resolved) {
+      throw new Error(`resource not found: ${uri}`);
+    }
+    const text = await readFile(resolved.abs, "utf8");
+    return { contents: [{ uri, mimeType: resolved.mimeType, text }] };
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error(`node-skills-server-example: serving ${skills.size} skill(s) from ${SKILLS_ROOT}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/node-skills-server/skills/git-workflow/SKILL.md
+++ b/examples/node-skills-server/skills/git-workflow/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: git-workflow
+description: Follow this team's Git conventions for branching and commits
+---
+
+# Git Workflow
+
+Use this workflow when creating branches or committing changes on behalf of the user.
+
+## Branching
+
+- Branch names: `<type>/<short-description>`, where `<type>` is one of `feat`, `fix`, `chore`, `docs`.
+- Branch off the default branch unless the user names a different base.
+
+## Commits
+
+- Write commit subjects in the imperative mood ("Add X", not "Added X").
+- Keep the subject line under 72 characters; wrap the body at 100.
+- Reference an issue number in the body when one exists (`Refs #123`), not the subject.
+
+## Before opening a PR
+
+- Confirm the branch builds and tests pass.
+- Squash fixup commits into their parent before pushing.

--- a/examples/node-skills-server/skills/pdf-processing/SKILL.md
+++ b/examples/node-skills-server/skills/pdf-processing/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: pdf-processing
+description: Extract text, form fields, and tables from PDF documents
+---
+
+# PDF Processing
+
+Use this skill when the user asks to read, extract, or summarize content from a PDF.
+
+## Choosing an approach
+
+- Plain text extraction: sufficient for most reading/summarization tasks.
+- Form fields: see `references/FORMS.md` for the field-extraction workflow — only load
+  that reference when the document actually contains fillable form fields.
+
+## General workflow
+
+1. Confirm the file is a real PDF (check the file signature, not just the extension).
+2. Extract text page-by-page rather than as one blob, so page references stay accurate.
+3. Note any pages that fail to extract (scanned/image-only pages need OCR, out of scope here).

--- a/examples/node-skills-server/skills/pdf-processing/references/FORMS.md
+++ b/examples/node-skills-server/skills/pdf-processing/references/FORMS.md
@@ -1,0 +1,9 @@
+# Extracting Form Fields
+
+Load this reference only when `SKILL.md` determines the document has fillable form fields.
+
+1. Enumerate form fields (name, type, current value) before attempting to read or fill any of them.
+2. Preserve field order as it appears in the document's field dictionary — visual layout order
+   can differ and is not reliable for programmatic access.
+3. When filling fields, validate each value against the field's declared type (text, checkbox,
+   radio, choice) before writing it back.


### PR DESCRIPTION
Closes #107.

Minimal, complete reference implementation of SEP-2640 (Skills Extension): discovers skills from a local directory, parses `SKILL.md` YAML frontmatter, and serves them as MCP resources under the `skill://` URI scheme via `resources/list` and `resources/read`.

## What's included

- `examples/node-skills-server/server.js` — the server itself, using `@modelcontextprotocol/sdk`
- Discovery + validation: `SKILL.md` frontmatter `name` must match its directory name and use the Agent Skills naming charset; nested skills (a `SKILL.md` inside another skill's directory) fail loudly at startup rather than silently mis-resolving `skill://` URIs later
- `skill://index.json` discovery index, per the SEP's enumeration section
- Sample skills (`git-workflow`, `pdf-processing` + a nested `references/FORMS.md`) — deliberately matching the SEP draft's own resource-mapping examples table, so the example doubles as a runnable version of the spec's own worked examples
- README with `npx @modelcontextprotocol/inspector` usage

## Design notes for reviewers

- **Follows the current SEP draft, not the issue's original sketch.** #107 mentioned `tools/list`/`tools/call` for skill "activation," but the SEP settled on Resources only (see its "Why Resources Instead of a New Primitive?" section, and the decision log). This implementation serves skills purely via `resources/list`/`resources/read` — no tools.
- **Uses the low-level `Server` class, not `McpServer`.** The SDK's own JSDoc reserves `Server` for "advanced use cases," and this is one: it declares the `io.modelcontextprotocol/skills` extension capability, which `@modelcontextprotocol/sdk`'s `ServerCapabilities` type doesn't model yet (SEP-2133 hasn't landed there — it still round-trips correctly at runtime, the SDK just doesn't type-check it). The custom `skill://<path>/<file>` resolution, where both segments are independently multi-segment, also doesn't map cleanly onto a single `ResourceTemplate`. Explicit request handlers additionally make the raw protocol shapes visible for anyone porting this pattern to another SDK/language.
- **Scope: text files only.** Binary assets would use the `blob` (base64) resource-content field instead of `text` — left out to keep the example focused on what every skill server needs.

## Verification

Tested end-to-end with a real MCP client (not just started/parsed): server capabilities, `resources/list` (index + all skill files), `resources/read` for a top-level `SKILL.md` and a nested reference file, and the not-found error path for an unknown `skill://` URI. All pass.

Happy to adjust naming/layout conventions if the WG prefers something different for `examples/`.