### PR TITLE
docs: add experimental findings template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,9 +45,11 @@ Outputs include:
 
 When adding experimental findings or new approaches:
 
+- Start from the [experimental findings template](docs/findings-template.md) when adding a finding
 - Include enough detail for others to reproduce or evaluate
 - Note which clients and servers were tested
 - Be explicit about what worked, what didn't, and what remains untested
+- Write "Not documented" for missing historical details instead of inferring them
 - Attribute community input with GitHub handles and link to the source where possible
 
 ### Community Input

--- a/docs/experimental-findings.md
+++ b/docs/experimental-findings.md
@@ -2,24 +2,39 @@
 
 > ℹ️ **This document is not actively maintained.** It captures a snapshot of early findings. Current discussion and decisions are tracked in the [meeting notes discussions](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/categories/meeting-notes-skills-over-mcp-wg), [Discord #skills-over-mcp-wg](https://discord.com/channels/1358869848138059966/1464745826629976084), and on the [SEP-2640 PR](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640).
 
-> **Contributing findings?** See [#50](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/50) for the contribution template proposal.
+> **Contributing findings?** Start with the [experimental findings template](findings-template.md).
 
 ## McpGraph: Skills in MCP Server Repo
 
-**Repo:** [TeamSparkAI/mcpGraph](https://github.com/TeamSparkAI/mcpGraph)
-**Skill:** [mcpgraphtoolkit/SKILL.md](https://github.com/TeamSparkAI/mcpGraph/blob/main/skills/mcpgraphtoolkit/SKILL.md) (875+ lines)
+**Date:** Not documented
 
-Bob Dickinson built a standalone SKILL.md file that lives in the same repo as the MCP server, but they weren't formally connected. The skill instructs agents on building directed graphs of MCP nodes to orchestrate tool calls.
+**Implementation:**
 
-**Findings:**
+- **Repository:** [TeamSparkAI/mcpGraph](https://github.com/TeamSparkAI/mcpGraph)
+- **Author:** Bob Dickinson
+- **Relevant artifacts:** [mcpgraphtoolkit/SKILL.md](https://github.com/TeamSparkAI/mcpGraph/blob/main/skills/mcpgraphtoolkit/SKILL.md) (875+ lines)
 
-- Claude ignored the SKILL.md initially, even when the skill and server had similar descriptions
-- Claude would fail at using the server tools a couple times, then read the skill and succeed
-- Expected Claude to start with the skill ("I know how to do X") before the server ("I do X"), but it didn't
+**Approach tested:** Related to [Approach 5: Server Instructions Reference](approaches.md#5-server-instructions-reference). The standalone skill lives beside the MCP server but is not formally connected to it.
 
-**Resolution:** Added a server instruction telling the agent to read the SKILL.md before using the tool. That one change caused Claude to reliably read the skill first.
+**Setup:**
 
-**Remaining concerns:**
+- **Clients tested:** Claude; specific client not documented
+- **Models tested:** Not documented
+- **Configuration notes:** The skill teaches agents to build directed graphs of MCP nodes and orchestrate tool calls
+
+**What was tested:** Whether an agent discovers and follows a colocated skill before attempting to use the server tools.
+
+**Results:**
+
+- **What worked:** Adding a server instruction that told the agent to read the skill before using the tool caused Claude to load it reliably
+- **What didn't:** Claude initially ignored the skill even when the skill and server had similar descriptions, and only read it after failing to use the server tools
+- **What was surprising:** A single server instruction changed the loading order reliably
+
+**Requirements or design questions addressed:** Reliable skill discovery and loading, and whether server instructions can connect an MCP server to colocated skill guidance.
+
+**Evidence and reproduction:** These are community-reported observations; the client version, model version, and runnable reproduction are not documented.
+
+**Limitations:**
 
 - This workaround works for 1:1 skill-to-server case, but doesn't solve discovery — users installing from a registry don't know to also install the skill
 - Distinguishes between "skill required to make the server work at all" vs. "skill that orchestrates tools you could use without it" — potentially different solutions needed
@@ -54,18 +69,39 @@ Introduces support for agent skills with a tools-based approach.
 
 ## NimbleBrain: skill:// Resource Consolidation
 
-[Mat Goldsborough](https://github.com/mgoldsborough) (NimbleBrain) had previously maintained separate components for MCP server code, a skills monorepo, and registry metadata with `server.json`. After community discussion, he consolidated into single atomic repos per server with skills exposed as `skill://` resources directly on the server.
+**Date:** Not documented
 
-**Findings:**
+**Implementation:**
 
-- Collapsing three separate artifacts into one repo simplified build, versioning, and deployment — skills are colocated with the tools they describe and shipped atomically
-- `skill://` resources enable ephemeral/installless availability: skill context is present while the server is installed and disappears when it disconnects, with no git cloning or file system access required on the client side
-- Quick tests showed same or better results compared to the previous approach of injecting skills upstream before the LLM call
-- Validates the skills-as-resources approach documented in [Approach 3](approaches.md#3-skills-as-tools-andor-resources)
+- **Repositories:** [mcp-ipinfo](https://github.com/NimbleBrainInc/mcp-ipinfo), [mcp-webfetch](https://github.com/NimbleBrainInc/mcp-webfetch), [mcp-pdfco](https://github.com/NimbleBrainInc/mcp-pdfco), [mcp-folk](https://github.com/NimbleBrainInc/mcp-folk), and [mcp-brave-search](https://github.com/NimbleBrainInc/mcp-brave-search)
+- **Author:** [Mat Goldsborough](https://github.com/mgoldsborough) (NimbleBrain)
+- **Relevant artifacts:** Atomic MCP server repositories with skills exposed as `skill://` resources
 
-**Reference implementations:** [mcp-ipinfo](https://github.com/NimbleBrainInc/mcp-ipinfo), [mcp-webfetch](https://github.com/NimbleBrainInc/mcp-webfetch), [mcp-pdfco](https://github.com/NimbleBrainInc/mcp-pdfco), [mcp-folk](https://github.com/NimbleBrainInc/mcp-folk), [mcp-brave-search](https://github.com/NimbleBrainInc/mcp-brave-search)
+**Approach tested:** [Approach 3: Skills as Tools and/or Resources](approaches.md#3-skills-as-tools-andor-resources).
 
-**Community input:**
+**Setup:**
+
+- **Clients tested:** Not documented
+- **Models tested:** Not documented
+- **Configuration notes:** Previously separate MCP server code, skills, and `server.json` registry metadata were consolidated into one repository per server
+
+**What was tested:** Whether colocating skills with their MCP servers and exposing them as resources simplifies distribution while preserving or improving agent results.
+
+**Results:**
+
+- **What worked:** Consolidating the artifacts simplified build, versioning, and deployment; skills ship atomically with the tools they describe
+- **What worked:** `skill://` resources provided ephemeral availability without git cloning or client-side file-system access
+- **What worked:** Quick tests produced the same or better results than injecting skills before the LLM call
+- **What didn't:** Not documented
+- **What was surprising:** Not documented
+
+**Requirements or design questions addressed:** Installless skill availability, provenance through colocation, atomic versioning, and reuse of existing MCP resource primitives.
+
+**Evidence and reproduction:** The linked repositories are reference implementations. The comparison with upstream skill injection was reported through community discussion; a test procedure and quantitative results are not documented.
+
+**Limitations:** Client versions, model versions, test cases, and evaluation criteria are not documented, so the result cannot yet be reproduced precisely.
+
+**Sources and attribution:**
 
 > "Skills living as skill:// resources on the server itself was the natural endpoint of that consolidation. The skill context is colocated with the tools it describes, versioned together, shipped together." — [Mat Goldsborough](https://github.com/mgoldsborough) (NimbleBrain), via Discord
 

--- a/docs/findings-template.md
+++ b/docs/findings-template.md
@@ -1,0 +1,41 @@
+# Experimental Findings Template
+
+Use this template when adding an entry to [experimental-findings.md](experimental-findings.md). Include enough evidence for another contributor to evaluate the result, and write "Not documented" rather than inferring missing details.
+
+---
+
+## [Implementation or experiment name]
+
+**Date:** YYYY-MM-DD or Not documented
+
+**Implementation:**
+
+- **Repository:** [name](URL)
+- **Author:** Name or handle
+- **Relevant artifacts:** Links to skill files, server/client code, commits, or pull requests
+
+**Approach tested:** Link to the relevant section of [approaches.md](approaches.md), or describe the approach if it is not listed.
+
+**Setup:**
+
+- **Clients tested:** Names and versions
+- **Models tested:** Names and versions
+- **Configuration notes:** Relevant server, runtime, dependency, and operating-system details
+
+**What was tested:** Describe the scenarios or behaviors evaluated.
+
+**Results:**
+
+- **What worked:** Observed successes
+- **What didn't:** Observed failures
+- **What was surprising:** Unexpected behavior
+
+**Requirements or design questions addressed:** Link the finding to the current [problem statement](problem-statement.md), [use cases](use-cases.md), or [approaches](approaches.md).
+
+**Evidence and reproduction:** Provide commands, configuration, logs, measurements, or links that let another contributor inspect or repeat the experiment.
+
+**Limitations:** State what remains untested, uncertain, or specific to the recorded environment.
+
+**Sources and attribution:** Link community input and identify contributors by name and handle where possible.
+
+---


### PR DESCRIPTION
## Summary

- add a reusable template for experimental findings
- retrofit the McpGraph and NimbleBrain entries to demonstrate the format without inferring missing historical details
- link the template from the findings document and contribution guidance

The issue referenced `docs/requirements.md`, which no longer exists. The template instead links contributors to the current problem statement, use cases, and approaches documents.

## Validation

- `git diff --check`
- verified all relative Markdown link targets in the changed files exist
- verified the template represents the issue's requested fields and at least two findings use the format

Closes #50

AI assistance was used while preparing this PR. I reviewed the final change, ran the validation listed above, and take responsibility for it.
