### PR TITLE
docs(related-work): add mcpkit (Go SDK) to community implementations

### DIFF
--- a/docs/related-work.md
+++ b/docs/related-work.md
@@ -45,6 +45,7 @@ External projects building on skills patterns or integrating skills into framewo
 | NimbleBrain registry | NimbleBrain | [registry.nimbletools.ai](https://registry.nimbletools.ai/) | Registry with skill metadata support |
 | NimbleBrain skill:// servers | NimbleBrain | [github.com/NimbleBrainInc](https://github.com/NimbleBrainInc) | skill:// resource colocation examples: [mcp-ipinfo](https://github.com/NimbleBrainInc/mcp-ipinfo), [mcp-webfetch](https://github.com/NimbleBrainInc/mcp-webfetch), [mcp-pdfco](https://github.com/NimbleBrainInc/mcp-pdfco), [mcp-folk](https://github.com/NimbleBrainInc/mcp-folk), [mcp-brave-search](https://github.com/NimbleBrainInc/mcp-brave-search) |
 | Kiro powers directory | Kiro | [github.com/kirodotdev/powers](https://github.com/kirodotdev/powers/) | Plugin directory bundling skills + MCP servers; active catalog (AWS, GCP migration, SAM, etc.) |
+| mcpkit (ext/skills) | Sri Panyam | [github.com/panyam/mcpkit](https://github.com/panyam/mcpkit) | Go SDK, server + host: SKILL.md, `skill://` resources, progressive disclosure (`skill://index.json` catalog + host `load_skill` tool); per-supporting-file digests with verified reads, resource-fetch size + per-server byte budget, `resources/directory/read`; no code-execution surface (enforced by a build-failing test); released in v0.3.0 |
 
 ## Related Ecosystem Work
 


### PR DESCRIPTION

## Motivation and Context

mcpkit's `ext/skills` serves skills as `skill://` resources with a `skill://index.json` catalog, and its host layer consumes them with a model-facing `load_skill` progressive-disclosure tool. It also implements per-supporting-file digests with verified reads, a resource-fetch size + per-server byte budget, and `resources/directory/read`, and has no code-execution surface (enforced by a build-failing test). It wasn't listed in the related-work tracker yet; this adds it. Picking up the open call to help keep the trackers current.

## How Has This Been Tested?
Documentation-only change (one table row). The claims in the entry were checked
against the implementation as released in v0.3.0.

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Docs-only change, so the tests / error-handling checklist items are N/A. The
entry follows the existing format of the Other Community Implementations table;
happy to move it or trim the description if the maintainers prefer.

I left "tests pass" and "error handling" unchecked on purpose — they're N/A for
a one-line docs row, and the Additional context note says so, which is more
honest than checking them.