### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+This repository follows the same security policy as the main Model Context Protocol project.
+
+Please see the [MCP Security Policy](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/SECURITY.md) for full details on reporting security issues, the trust model, and what is considered in scope.
+
+## Reporting Security Issues
+
+If you discover a security vulnerability in this repository, please report it through
+the [GitHub Security Advisory process](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)
+for this repository.
+
+Please **do not** report security vulnerabilities through public GitHub issues, discussions,
+or pull requests.


### PR DESCRIPTION
Adds a `SECURITY.md` matching the one in [modelcontextprotocol/ext-tasks](https://github.com/modelcontextprotocol/ext-tasks/blob/main/SECURITY.md).

It defers to the main [MCP Security Policy](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/SECURITY.md) for the trust model and scope, and directs vulnerability reports to this repository's GitHub Security Advisory process rather than public issues, discussions, or PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Requested by **Peter** · [Claude session #01Sure6S](https://claude.ai/code/session_01Sure6Sknngow87Q6TkzTfL)_